### PR TITLE
Add Moodle App guide

### DIFF
--- a/docs/guides/moodleapp/01-overview.md
+++ b/docs/guides/moodleapp/01-overview.md
@@ -1,0 +1,62 @@
+---
+title: Moodle App Overview
+---
+
+The Moodle App is a mobile application that helps users make the best of their Moodle sites on handheld devices. It has some additional features like offline access, and a dedicated interface adapted to mobile. It's focused on student functionality, so you won’t find all the features you have on the web for teachers and admins. You can learn more about the features available in [the user documentation](https://docs.moodle.org/).
+
+On a technical level, it's a completely different codebase from the Moodle LMS, and interacts with a Moodle site using [web services](#). You can find the source code of the application in github: [github.com/moodlehq/moodleapp](https://github.com/moodlehq/moodleapp).
+
+Before embarking into any Moodle-specific documentation, we recommend that you are at least familiar with [Angular](https://angular.io/) and [Ionic Framework](https://ionicframework.com/). These are the core technologies used in the application. We'll reference any relevant concepts, but having a basic idea will take you a long way in understanding the Moodle App.
+
+## Basic concepts
+
+### How does it work?
+
+When you are accessing a Moodle site on the web, you are only capable of using one site at a time. In contrast to that, the Moodle App can be used with multiple sites at once. However, you will need to switch sessions to interact with each site, so you won’t be able to use multiple sites simultaneously (but you'll continue receiving push notifications and reminders for all the sites connected in the app).
+
+This works because the app is not coupled to any specific Moodle site, it acts as a client that will connect with a site after logging in; using the site url and user credentials. Compared to the Moodle LMS, users can always use the latest version of the app even if the site is running an old version. Some features may be missing or change depending on the version of the site, but it will work the same way for the most part.
+
+The app can also be compiled to work with a single site, or a list of approved sites. Which may be desirable for building custom applications. For most people though, [the official app from MoodleHQ](https://moodle.com/app/) will be sufficient because it’s not restricted to any site.
+
+Keep in mind that the application only works with moodle sites that allow it, and this is disabled by default. If you want to allow users to log into your site using the app, make sure to [enable it in the settings](https://docs.moodle.org/311/en/Moodle_app_guide_for_admins#Enable_mobile_services_on_your_site). If you are not the site owner, reach out to the administrators.
+
+### Architecture
+
+The code of the application follows an [hexagonal architecture](https://en.wikipedia.org/wiki/Hexagonal_architecture_(software)), with core modules that include the main functionality and addon modules that provide additional features.
+
+Class names are prefixed by their module, so that you can identify whether you’re working with something in core or an addon. For example, `CoreCourseProvider` is a core service implementing course features, while `AddonMessagesProvider` is an addon service related with messaging.
+
+These modules are defined as [Angular Modules](https://angular.io/guide/architecture-modules), and they are resolved at runtime using [Angular's dependency injection framework](https://angular.io/guide/architecture-services).
+
+Pages and navigation are defined using [Angular Router](https://angular.io/guide/routing-overview), making heavy use of [lazy loading](https://angular.io/guide/lazy-loading-ngmodules).
+
+### Web services and caching
+
+TODO
+
+### Delegates and handlers
+
+TODO
+
+### Site plugins
+
+TODO
+
+## Platform Support
+
+The Moodle App only works with Moodle sites running version 3.1 or newer.
+
+The minimum platforms supported by the application are Android 5.1 (with Webview 61 or higher) and iOS 11.
+
+Browsers are not officially supported, but you can use a Chromium-based browser for development if you don’t need any native functionality. However, there are [some caveats](#) you should be aware of.
+
+## Where to go next
+
+Now that you are familiar with the basic concepts, you understand how the application works, and you’ve got your development environment set up; you're ready to embark into the particulars of what you're trying to achieve.
+
+- Do you want to contribute to the core? Read the [Moodle App Development Guide](#).
+- Do you want to adapt a plugin to mobile? Read the [Moodle App Plugins Development Guide](#).
+- Do you want to customise your site in the app? Read the [Moodle App Customisation](#) page.
+- Do you want to make a custom app? Read the [Custom Moodle Apps](#) page.
+
+If you have any further questions, check out the [FAQ](#). If there's anything you want to share, you can do it in [the forum](https://moodle.org/mod/forum/view.php?id=7798) or [the Telegram developer room](#). You can also report any bugs that you find in [the tracker](https://tracker.moodle.org/browse/MOBILE).

--- a/docs/guides/moodleapp/02-coding-style.md
+++ b/docs/guides/moodleapp/02-coding-style.md
@@ -1,0 +1,74 @@
+---
+title: Moodle App Coding Style
+---
+
+This document outlines the exceptions to the [Coding style](#) and [JavaScript Coding Style](#) which apply to the Moodle App and also includes rules for other technologies that are used in the app, like Typescript and Angular.
+
+Unless otherwise specified, developers should follow the indications included on those documents.
+
+Most rules are enforced with [ESLint](https://github.com/typescript-eslint/typescript-eslint) and won’t be mentioned in this document, make sure to integrate a linter in your development environment.
+
+## Goals
+
+Consistent coding style is important in any development project, and particularly when many developers are involved. A standard style helps to ensure that the code is easier to read and understand, which helps overall quality.
+
+Abstract goals we strive for:
+
+- simplicity
+- readability
+- tool friendliness
+
+Note that much of the existing code may not follow all of these guidelines — we continue to upgrade this code when we see it.
+
+## TypeScript
+
+### Disabling ESLint rules
+
+In some situations, it may be necessary to [disable ESLint rules using inline comments](https://eslint.org/docs/user-guide/configuring/rules#disabling-rules). Although this is discouraged, it is allowed on certain use-cases.
+
+Most of the time, however, this could be solved by refactoring code. So think twice before disabling a rule.
+
+Warnings should be treated with the same severity as errors, even if they are allowed by the linter. The reasoning behind this is that warnings are useful when new rules are introduced that affect existing code, but new code should always conform to the rules or explicitly disable them.
+
+### Using async / await
+
+Using async/await is encouraged, but it shouldn’t be mixed with .then/.catch/.finally. Using both can make code difficult to understand. As a rule of thumb, there should only be one style in a given function.
+
+✔️ Good
+
+```ts
+async function greet() {
+    const response = await fetch('/profile.json');
+    const data = await response.json();
+
+    alert(`Hello, ${data.name}!`);
+}
+```
+
+⚠️ Allowed, but discouraged
+
+```ts
+function greet() {
+    return fetch('/profile.json')
+        .then(response => response.json())
+        .then(data => {
+            alert(`Hello, ${data.name}!`);
+        });
+}
+```
+
+❌ Bad
+
+```ts
+async function greet() {
+    const response = await fetch('/profile.json');
+
+    return response.json().then(data => {
+        alert(`Hello, ${data.name}!`);
+    });
+}
+```
+
+Async/await is [syntactic sugar](https://en.wikipedia.org/wiki/Syntactic_sugar) for Promises, so it should always be possible to avoid using .then/.catch/.finally.
+
+To prevent making asynchronous operations difficult to spot, using await should be limited to simple statements such as one liners, assignments and if guards with a single condition.

--- a/docs/guides/moodleapp/index.md
+++ b/docs/guides/moodleapp/index.md
@@ -1,0 +1,17 @@
+---
+title: Moodle App
+---
+
+Welcome to the Moodle App developer documentation!
+
+Here, you will find everything you need to start working with the Moodle App right away.
+
+We suggest that you read the [Moodle App Overview](./01-overview.md) before diving into specifics. Once you're familiar with the basic concepts and understand how the application works, you can dig into the particulars:
+
+- Do you want to contribute to the core? Read the [Moodle App Development Guide](#).
+- Do you want to adapt a plugin to mobile? Read the [Moodle App Plugins Development Guide](#).
+- Do you want to customise your site in the app? Read the [Moodle App Customisation](#) page.
+- Do you want to make a custom app? Read the [Custom Moodle Apps](#) page.
+
+
+If you have any further questions, check out the [FAQ](#). If there's anything you want to share, you can do it in [the forum](https://moodle.org/mod/forum/view.php?id=7798) or [the Telegram developer room](#). You can also report any bugs that you find in [the tracker](https://tracker.moodle.org/browse/MOBILE).


### PR DESCRIPTION
I've migrated some of the Moodle App documentation, here's some things I noticed:

- I never use `yarn` so I installed it with `npm` anyways, it worked well.
- We're missing a `.nvmrc` file, I was using node v14 and I got an error because `String.replaceAll` is not supported.
- At first it was confusing to create new pages. I started creating them in `/docs`, but that didn't work because the links at the top take you to the 4.0 docs. Later I noticed that clicking the "quick start" link on the home page takes you to the next version. So it is confusing because depending where you click, it takes you to a different version. Although I guess this is fine once you get used to it, but it could trip up some contributors getting started.
- It would be nice to have something to automatically rename all references when files are renamed. Whilst I like the pure markdown approach, maybe we could have some scripts in CI checking for link integrity (at least internal links).
- I noticed that some links are written using a convention for writting them at the bottom of the file instead of inline markdown. If these such practices are mandatory, I think we should also do something in CI or somewhere else to enforce it because it's very easy to forget (I haven't done it at all in this PR).

Other than these small things, I think it was quite easy to get started. I haven't done anything complex, but it seems like it would be easy to learn more.