### PR TITLE
Add linting and style checks

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -1,0 +1,18 @@
+# URL
+# ===
+# The default URL for build content is https://develop.moodle.org.
+# For local development you may wish to specify an alternative for your own environment.
+#
+# url=http://localhost
+# url=https://develop.moodle.org
+
+# Base URL
+# ========
+# When hosting the content from a webroot, absolutely paths are often used.
+#
+# The baseUrl should be the location of the root of the project on your local host.
+# For example, if you have your content hosted locally at http://localhost/devdocs Then the baseUrl would be `devdocs`.
+# The default value is `/`.
+#
+# baseUrl=/devdocs/
+# baseUrl=/

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,0 +1,24 @@
+name: "Lint for Pull Requests"
+
+on:
+  pull_request:
+    paths:
+      - 'docs/**/*.md'
+      - 'general/**/*.md'
+      - .markdownlint.yaml
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v3.0.0
+        with:
+          node-version: "16"
+
+      - name: Lint markdown files
+        run: |
+          npx markdownlint-cli '*.md' -i LICENSE.md -i CODE_OF_CONDUCT.md -i README.me

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -1,0 +1,20 @@
+name: Lint on push (project files)
+
+on:
+  push:
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v3.0.0
+        with:
+          node-version: "16"
+
+      - name: Lint markdown files
+        run: |
+          npx markdownlint-cli '*.md' -i LICENSE.md -i CODE_OF_CONDUCT.md -i README.me

--- a/.github/workflows/new-issues.yml
+++ b/.github/workflows/new-issues.yml
@@ -1,0 +1,16 @@
+name: 'Mark new issues with needs-triage label'
+
+on:
+  issues:
+    types:
+      - reopened
+      - opened
+
+jobs:
+  label-new-issues:
+    runs-on: ubuntu-latest
+    steps:
+      - name: initial labelling
+        uses: andymckay/labeler@master
+        with:
+          add-labels: "needs-triage"

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 .env
+.github/styles/Microsoft
+.github/styles/write-good

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,182 @@
+# For full details on all of these configuration settings:
+# https://github.com/DavidAnson/markdownlint#rules--aliases
+
+# Set the default state for all rules.
+default: true
+
+# MD001/heading-increment/header-increment - Heading levels should only increment by one level at a time
+# MD002/first-heading-h1/first-header-h1 - First heading should be a top-level heading
+# MD003/heading-style/header-style - Heading style
+
+# MD004/ul-style - Unordered list style
+MD004:
+  style: dash
+
+# MD005/list-indent - Inconsistent indentation for list items at the same level
+# MD006/ul-start-left - Consider starting bulleted lists at the beginning of the line
+
+# MD007/ul-indent - Unordered list indentation
+# MD009/no-trailing-spaces - Trailing spaces
+# MD010/no-hard-tabs - Hard tabs
+# MD011/no-reversed-links - Reversed link syntax
+# MD012/no-multiple-blanks - Multiple consecutive blank lines
+
+# MD013/line-length - Line length
+# Disable for better readability.
+MD013: false
+
+# MD014/commands-show-output - Dollar signs used before commands without showing output
+MD014: false
+
+# MD018/no-missing-space-atx - No space after hash on atx style heading
+# MD019/no-multiple-space-atx - Multiple spaces after hash on atx style heading
+# MD020/no-missing-space-closed-atx - No space inside hashes on closed atx style heading
+# MD021/no-multiple-space-closed-atx - Multiple spaces inside hashes on closed atx style heading
+# MD022/blanks-around-headings/blanks-around-headers - Headings should be surrounded by blank lines
+# MD023/heading-start-left/header-start-left - Headings must start at the beginning of the line
+
+# MD024/no-duplicate-heading/no-duplicate-header - Multiple headings with the same content
+MD024: false
+
+# MD025/single-title/single-h1 - Multiple top-level headings in the same document
+
+# MD026/no-trailing-punctuation - Trailing punctuation in heading
+MD026: false
+
+# MD027/no-multiple-space-blockquote - Multiple spaces after blockquote symbol
+
+# MD028/no-blanks-blockquote - Blank line inside blockquote
+MD028: false
+
+# MD029/ol-prefix - Ordered list item prefix
+# MD030/list-marker-space - Spaces after list markers
+# MD031/blanks-around-fences - Fenced code blocks should be surrounded by blank lines
+# MD032/blanks-around-lists - Lists should be surrounded by blank lines
+
+# MD033/no-inline-html - Inline HTML
+MD033:
+  # Allowed elements
+  allowed_elements:
+    - a
+    - abbr
+    - annotation
+    - base
+    - br
+    - caption
+    - cite
+    - code
+    - col
+    - colgroup
+    - dd
+    - details
+    - dfn
+    - div
+    - dl
+    - dt
+    - em
+    - h4
+    - h5
+    - img
+    - kbd
+    - li
+    - math
+    - menclose
+    - mfenced
+    - mfrac
+    - mfrac
+    - mi
+    - mmultiscripts
+    - mn
+    - mo
+    - mover
+    - mphantom
+    - mprescripts
+    - mroot
+    - mrow
+    - ms
+    - mspace
+    - mspace
+    - msqrt
+    - mstyle
+    - msub
+    - msubsup
+    - msup
+    - mtable
+    - mtd
+    - mtext
+    - mtr
+    - munder
+    - munderover
+    - none
+    - ol
+    - p
+    - pre
+    - q
+    - section
+    - semantics
+    - span
+    - strong
+    - sub
+    - summary
+    - sup
+    - table
+    - tbody
+    - td
+    - tfoot
+    - th
+    - thead
+    - tr
+    - tt
+    - ul
+    - var
+
+    # These are custom React elements, either from Docusaurus, or our own.
+    - CodeBlock
+    - Tabs
+    - TabItem
+    - TabItems
+    - Since
+    - DeprecatedSince
+    - ValidExample
+    - InvalidExample
+
+# MD034/no-bare-urls - Bare URL used
+MD034: false
+
+# MD035/hr-style - Horizontal rule style
+
+# MD036/no-emphasis-as-heading/no-emphasis-as-header - Emphasis used instead of a heading
+MD036: false
+
+# MD037/no-space-in-emphasis - Spaces inside emphasis markers
+MD037: false
+
+# MD038/no-space-in-code - Spaces inside code span elements
+# MD039/no-space-in-links - Spaces inside link text
+
+# MD040/fenced-code-language - Fenced code blocks should have a language specified
+MD040: false
+
+# MD041/first-line-heading/first-line-h1 - First line in a file should be a top-level heading
+
+# MD042/no-empty-links - No empty links
+MD042: false
+
+# MD043/required-headings/required-headers - Required heading structure
+# MD044/proper-names - Proper names should have the correct capitalization
+
+# MD045/no-alt-text - Images should have alternate text (alt text)
+MD045: false
+
+# MD046/code-block-style - Code block style
+MD046:
+  style: fenced
+
+# MD047/single-trailing-newline - Files should end with a single newline character
+# MD048/code-fence-style - Code fence style
+
+# MD049/emphasis-style - Emphasis style should be consistent
+MD049: false
+
+# MD050/strong-style - Strong style should be consistent
+MD050: false

--- a/README.md
+++ b/README.md
@@ -1,14 +1,41 @@
-# Website
+# Moodle Developer Resoruces
 
-This website is built using [Docusaurus 2](https://docusaurus.io/), a modern static website generator.
+[![Lint](https://github.com/andrewnicols/dinodevdocs/actions/workflows/markdown-lint.yml/badge.svg)](https://github.com/andrewnicols/dinodevdocs/actions/workflows/markdown-lint.yml)
+[![Build](https://github.com/andrewnicols/dinodevdocs/actions/workflows/pages/pages-build-deployment/badge.svg)](https://github.com/andrewnicols/dinodevdocs/actions/workflows/pages/pages-build-deployment)
+[![Deployment](https://github.com/andrewnicols/dinodevdocs/actions/workflows/deploy.yml/badge.svg)](https://github.com/andrewnicols/dinodevdocs/actions/workflows/deploy.yml)
 
-### Installation
+## Introduction
+
+This repository includes the source for the Moodle Developer Resources - a
+collection of resources aimed at making your life as a Moodle Developer easier.
+
+## Contributing
+
+These resources are written by developers, for developers. We value your input
+and your help in adding to them.
+
+There are many ways that you can help, from reporting inaccuracies, and missing
+documentation, to making small corrections and, of course, creating new
+resources for others to make use of.
+
+If you plan to contribute, then you may wish to setup a local development
+environment to make it easier to do so.
+
+## Local development environment
+
+The Moodle Developer Resources are compiled using the
+[Docusaurus](https://docusauris.io) tooling, which can be easily installed with
+[Yarn](https://yarnpkg.com/getting-started/install).
+
+Once installed, you should invoke yarn:
 
 ```
 $ yarn
 ```
 
-### Local Development
+This will install all of the dependencies needed to run the development server.
+
+Finally you can start the server with:
 
 ```
 $ yarn start
@@ -16,26 +43,70 @@ $ yarn start
 
 This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.
 
-### Build
+There are some other commands that you may find useful:
+
+### Linting your content
+
+One of the many powerful features of Markdown is its ability to be
+programmatically checked for a range of bugs and stylistic errors.
+
+Every time a commit is pushed to source repository it is passed through several
+linting tools which it must pass before it can be merged.
+
+You can lint your code before pushing it using yarn:
 
 ```
-$ yarn build
+yarn lint
 ```
 
-This command generates static content into the `build` directory and can be served using any static contents hosting service.
+This will run the `markdownlint` CLI tool across all of the documentation
+directories and report any issues it comes across.
 
-### Deployment
+Some examples of these issues include:
 
-Using SSH:
+- header levels which do not increase incrementally
+- multiple level 1 headers (`h1`)
+- use of hard tabs instead of spaces
+- the presence of trailing spaces at the end of a line
+
+These are usually easy to solve and, in many cases, can be fixed automatically.
+
+### Stylistic checks
+
+The Moodle Developer Resources try to follow the [Microsoft writing style
+guide](https://docs.microsoft.com/en-us/style-guide).
+
+This is a free writing style and terminology guide aimed at authors of
+technology-related documentation. Adopting this writing-style guide is intended
+to make all of the documentation clearer, more consistent, and easier to
+understand for developers who are not native English speakers.
+
+A number of key rules have been adopted, and others are treated as
+recommendations which you can follow where appropriate.
+
+You can run the style checks on your content using yarn:
+
+### Building your content
+
+During development you will almost certainly want to use the yarn development
+server, however you will sometimes need to build the content to use certain
+features.
+
+This is easily achieved with yarn:
 
 ```
-$ USE_SSH=true yarn deploy
+yarn build
 ```
 
-Not using SSH:
+This command will compile all of the documentation into static HTML files
+complete with all appropriate resources.
 
-```
-$ GIT_USER=<Your GitHub username> yarn deploy
-```
+As part of this build, the validity of all internal links will be checked. For
+this reason we strongly recommend building the content locally before submitting
+a pull request as broken internal links will lead to a build failure
+immediately.
 
-If you are using GitHub pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.
+You may also need to configure the build to view it locally. This can be
+achieved using a `.env` file in the project root.
+For more information on the format of the `.env` file, see the documentation in
+the `.env.default` file.

--- a/docs/apis.md
+++ b/docs/apis.md
@@ -7,188 +7,248 @@ Moodle has a number of core APIs that provide tools for Moodle scripts.
 They are essential when writing [[Plugins|Moodle plugins]].
 
 ## Most-used General API
+
 These APIs are critical and will be used by nearly every Moodle plugin.
 
 ### Access API (access)
+
 The [Access API](./apis/access) gives you functions so you can determine what the current user is allowed to do, and it allows modules to extend Moodle with new capabilities.
 
 ### Data manipulation API (dml)
+
 The [[Data manipulation API]] allows you to read/write to databases in a consistent and safe way.
 
 ### File API (files)
+
 The [[File API]] controls the storage of files in connection to various plugins.
 
 ### Form API (form)
+
 The [[Form API]] defines and handles user data via web forms.
 
 ### Logging API (log)
+
 The [[Events API]] allows you to log events in Moodle, while [[Logging 2]] describes how logs are stored and retrieved.
 
 ### Navigation API (navigation)
+
 The [[Navigation API]] allows you to manipulate the navigation tree to add and remove items as you wish.
 
 ### Page API (page)
+
 The [[Page API]] is used to set up the current page, add JavaScript, and configure how things will be displayed to the user.
 
 ### Output API (output)
+
 The [[Output API]] is used to render the HTML for all parts of the page.
 
 ### String API (string)
+
 The [[String API]] is how you get language text strings to use in the user interface. It handles any language translations that might be available.
 
 ### Upgrade API (upgrade)
+
 The [[Upgrade API]] is how your module installs and upgrades itself, by keeping track of its own version.
 
 ### Moodlelib API (core)
+
 The [[Moodlelib API]] is the central library file of miscellaneous general-purpose Moodle functions. Functions can over the handling of request parameters, configs, user preferences, time, login, mnet, plugins, strings and others. There are plenty of defined constants too.
 
 ## Other General API
 
 ### Admin settings API (admin)
+
 The [[Admin settings]] API deals with providing configuration options for each plugin and Moodle core.
 
 ### Admin presets API (adminpresets)
+
 The [[AdminPresetsAPI|Admin presets API]] allows plugins to make some decisions/implementations related to the Site admin presets.
 
 ### Analytics API (analytics)
+
 The [[Analytics API]] allow you to create prediction models and generate insights.
 
 ### Availability API (availability)
+
 The [[Availability API]] controls access to activities and sections.
 
 ### Backup API (backup)
+
 The [[Backup API]] defines exactly how to convert course data into XML for backup purposes, and the [[Restore API]] describes how to convert it back the other way.
 
 ### Cache API (cache)
+
 The [[The Moodle Universal Cache (MUC)]] is the structure for storing cache data within Moodle. [[Cache_API]] explains some of what is needed to use a cache in your code.
 
 ### Calendar API (calendar)
+
 The [[Calendar API]] allows you to add and modify events in the calendar for user, groups, courses, or the whole site.
 
 ### Check API (check)
+
 The [[Check API]] allows you to add security, performance or health checks to your site.
 
 ### Comment API (comment)
+
 The [[Comment API]] allows you to save and retrieve user comments, so that you can easily add commenting to any of your code.
 
 ### Competency API (competency)
+
 The [[Competency API]] allows you to list and add evidence of competencies to learning plans, learning plan templates, frameworks, courses and activities.
 
 ### Data definition API (ddl)
+
 The [[Data definition API]] is what you use to create, change and delete tables and fields in the database during upgrades.
 
 ### Editor API
+
 The [[Editor API]] is used to control HTML text editors.
 
 ### Enrolment API (enrol)
+
 The [[Enrolment API]] deals with course participants.
 
 ### Events API (event)
+
 The [[Events API]] allows to define "events" with payload data to be fired whenever you like, and it also allows you to define handlers to react to these events when they happen. This is the recommended form of inter-plugin communication. This also forms the basis for logging in Moodle.
 
 ### Experience API (xAPI)
+
 The Experience API (xAPI) is an e-learning standard that allows learning content and learning systems to speak to each other. The [[Experience API (xAPI)]]
 allows any plugin to generate and handle xAPI standard statements.
 
 ### External functions API (external)
+
 The [[External functions API]] allows you to create fully parametrised methods that can be accessed by external programs (such as [[Web services]]).
 
 ### Favourites API
+
 The [[Favourites API]] allows you to mark items as favourites for a user and manage these favourites. This is often referred to as 'Starred'.
 
 ### H5P API (h5p)
+
 The [[H5P API]] allows plugins to make some decisions/implementations related to the [[H5P|H5P integration]].
 
 ### Lock API (lock)
+
 The [[Lock API]] lets you synchronise processing between multiple requests, even for separate nodes in a cluster.
 
 ### Message API (message)
+
 The [[Message API]] lets you post messages to users. They decide how they want to receive them.
 
 ### Media API (media)
+
 The [[Media_players#Using_media_players|Media]] API can be used to embed media items such as audio, video, and Flash.
 
 ### My profile API
+
 The [[My profile API]] is used to add things to the profile page.
 
 ### OAuth 2 API (oauth2)
+
 The [[OAuth 2 API]] is used to provide a common place to configure and manage external systems using OAuth 2.
 
 ### Payment API (payment)
+
 The [[Payment API]] deals with payments.
 
 ### Preference API (preference)
+
 The [[Preference API]] is a simple way to store and retrieve preferences for individual users.
 
 ### Portfolio API (portfolio)
+
 The [[Portfolio API]] allows you to add portfolio interfaces on your pages and allows users to package up data to send to their portfolios.
 
 ### Privacy API (privacy)
+
 The [[Privacy API]] allows you to describe the personal data that you store, and provides the means for that data to be discovered, exported, and deleted on a per-user basis.
 This allows compliance with regulation such as the General Data Protection Regulation (GDPR) in Europe.
 
 ### Rating API (rating)
+
 The [[Rating API]] lets you create AJAX rating interfaces so that users can rate items in your plugin. In an activity module, you may choose to aggregate ratings to form grades.
 
 ### Report builder API (reportbuilder)
+
 The [[Report builder API]] allows you to create reports in your plugin, as well as providing custom reporting data which users can use to build their own reports.
 
 ### RSS API (rss)
+
 The [[RSS API]] allows you to create secure RSS feeds of data in your module.
 
 ### Search API (search)
+
 The [[Search API]] allows you to index contents in a search engine and query the search engine for results.
 
 ### Tag API (tag)
+
 The [[Tag API]] allows you to store tags (and a tag cloud) to items in your module.
 
 ### Task API (task)
+
 The [[Task API]] lets you run jobs in the background. Either once off, or on a regular schedule.
 
 ### Time API (time)
+
 The [[Time API]] takes care of translating and displaying times between users in the site.
 
 ### Testing API (test)
+
 The testing API contains the Unit test API ([[PHPUnit]]) and Acceptance test API ([[Acceptance testing]]). Ideally all new code should have unit tests written FIRST.
 
 ### User-related APIs (user)
+
 This is a rather informal grouping of miscellaneous [[User-related APIs]] relating to sorting and searching lists of users.
 
 ### Web services API (webservice)
+
 The [[Web services API]] allows you to expose particular functions (usually external functions) as web services.
 
 ### Badges API (badges)
+
 The [https://docs.moodle.org/dev/OpenBadges_User_Documentation Badges] user documentation (is a temp page until we compile a proper page with all the classes and APIs that allows you to manage particular badges and OpenBadges Backpack).
 
 ### Custom fields API
+
 The [[Custom fields API]] allows you to configure and add custom fields for different entities
 
 ## Activity module APIs
+
 Activity modules are the most important plugin in Moodle. There are several core APIs that service only Activity modules.
 
 ### Activity completion API (completion)
+
 The [[Activity completion API]] is to indicate to the system how activities are completed.
 
 ### Advanced grading API (grading)
+
 The [[Advanced grading API]] allows you to add more advanced grading interfaces (such as rubrics) that can produce simple grades for the gradebook.
 
 ### Conditional activities API (condition) - deprecated in 2.7
+
 The deprecated [[Conditional activities API]] used to provide conditional access to modules and sections in Moodle 2.6 and below. It has been replaced by the [[Availability API]].
 
 ### Groups API (group)
+
 The [[Groups API]] allows you to check the current activity group mode and set the current group.
 
 ### Gradebook API (grade)
+
 The [[Gradebook API]] allows you to read and write from the gradebook. It also allows you to provide an interface for detailed grading information.
 
 ### Plagiarism API (plagiarism)
+
 The [[Plagiarism API]] allows your activity module to send files and data to external services to have them checked for plagiarism.
 
 ### Question API (question)
+
 The [[Question API]] (which can be divided into the Question bank API and the Question engine API), can be used by activities that want to use questions from the question bank.
 
 ## See also
-* [[Plugins]] - plugin types also have their own APIs
-* [[Callbacks]] - list of all callbacks in Moodle
-* [[Coding style]] - general information about writing PHP code for Moodle
-* [[Session locks]]
+
+- [[Plugins]] - plugin types also have their own APIs
+- [[Callbacks]] - list of all callbacks in Moodle
+- [[Coding style]] - general information about writing PHP code for Moodle
+- [[Session locks]]

--- a/docs/apis/access.md
+++ b/docs/apis/access.md
@@ -35,6 +35,7 @@ All users that did not log-in yet automatically get the default role defined in 
 Capabilities are defined by `$capabilities` array defined in `db/access.php` files. The name of the capability consists of `plugintype/pluginname:capabilityname`.
 
 For example:
+
 ```php title="mod/folder/db/access.php"
 $capabilities = [
     'mod/folder:managefiles' => [
@@ -61,6 +62,7 @@ Where the meaning of array keys is:
 It is necessary to bump up plugin version number after any change in db/access.php, so that the upgrade scripts can make the necessary changes to the database.  To run the upgrade scripts, log in to Moodle as administrator, navigate to the site home page, and follow the instructions.  (If you need to test the upgrade script without changing the plugin version, it is also possible to set back the version number in the mdl_block or mdl_modules table in the database.)
 
 The capability names are defined in plugin language files, the name of the string consists of "pluginname:capabilityname", in the example above it would be:
+
 ```php title="mod/folder/lang/en/folder.php"
 $string['folder:managefiles'] = 'Manage files in folder module';
 ```
@@ -72,6 +74,7 @@ $string['folder:managefiles'] = 'Manage files in folder module';
 In plugins context instances are usually only instantiated because they are instantiated and deleted automatically by the system.
 
 Fetching by object id:
+
 ```php
 $systemcontext = context_system::instance();
 $usercontext = context_user::instance($user->id);
@@ -82,11 +85,13 @@ $contextblock = context_block::instance($this->instance->id);
 ```
 
 Fetching by context id:
+
 ```php
 $context = context::instance_by_id($contextid);
 ```
 
 Notes:
+
 - by default exception is thrown if context can not be created
 - deleted users do not have contexts any more
 
@@ -95,7 +100,9 @@ Notes:
 When implementing access control always ask "Does the user have capability to do something?". It is incorrect to ask "Does the user have a role somewhere?".
 
 #### has_capability()
+
 `has_capability()` is the most important function:
+
 ```php
 function has_capability(
     string $capability,
@@ -106,6 +113,7 @@ function has_capability(
 ```
 
 Check whether a user has a particular capability in a given context. For example:
+
 ```php
 $context = context_module::instance($cm->id);
 if (has_capability('mod/folder:managefiles', $context)) {
@@ -116,6 +124,7 @@ if (has_capability('mod/folder:managefiles', $context)) {
 By default checks the capabilities of the current user, but you can pass a different userid. By default will return true for admin users, it is not recommended to use false here.
 
 #### require_capability()
+
 Function require_capability() is very similar, it is throwing access control exception if user does not have the capability.
 
 ```php
@@ -145,6 +154,7 @@ function is_viewing(context $context, $user = null, $withcapability = _)
 Each plugin script should include require_login() or require_course_login() after setting up PAGE->url.
 
 This function does following:
+
 - it verifies that user is logged in before accessing any course or activities (not-logged-in users can not enter any courses).
 - user is logged in as gu
 - verify access to hidden courses and activities
@@ -165,6 +175,7 @@ It is strongly discouraged to use is_siteadmin() in activity modules, please use
 #### `is_guest()`, `is_viewing()` and `is_enrolled()`
 
 In order to access course data one of these functions must return true for user:
+
 - `is_enrolled()` - user has active record in user_enrolments table
 - `is_viewing()` - user has 'moodle/course:view' capability (may access course, but is not considered to be participant)
 - `is_guest()` - user was given temporary guest access by some enrolment plugin
@@ -174,6 +185,7 @@ In order to access course data one of these functions must return true for user:
 This method returns list of users with given capability, it ignores enrolment status and should be used only above the course context.
 
 ## See also
+
 - [[Core APIs]]
 - [[Roles]]
 - [[Role archetypes]]

--- a/docs/gettingstarted/quickstart.md
+++ b/docs/gettingstarted/quickstart.md
@@ -3,7 +3,7 @@ title: Quick start
 sidebar_position: 1
 ---
 
-# A quick start to Moodle development
+## A quick start to Moodle development
 
 There are several ways to get started with Moodle depending on whether you prefer to use a container environment like
 docker, or to run Moodle on your machine directly.
@@ -11,20 +11,20 @@ docker, or to run Moodle on your machine directly.
 Several tools have been created by Moodle developers to make the development process easier for everyone. We welcome you
 to try these out and see if they help in your own workflows.
 
-## Docker
+### Docker
 
 :::note TODO
 Get someone to write a guide to installing a development environment using Docker.
 It is safe to assume that Docker has already been installed.
 :::
 
-## MacOS
+### MacOS
 
 If you prefer to have all of your development directly on your machine, without the use of Docker, then there are two
 main approaches. Many prefer to install packages using [Homebrew](https://brew.sh/), whilst others prefer
 [MacPorts](https://www.macports.org/). Both are powerful approaches and the choice is yours.
 
-### Homebrew
+#### Homebrew
 
 We can highly recommend this guide, courtesy of [Grav](https://getgrav.org/).
 It details installing your web development environment on MacOS using Homebrew:
@@ -35,19 +35,19 @@ It details installing your web development environment on MacOS using Homebrew:
 Get someone to write a guide to installing a development environment using MacOS with Brew
 :::
 
-### MacPorts
+#### MacPorts
 
 :::note TODO
 Get someone to write a guide to installing a development environment using MacPorts
 :::
 
-## Linux
+### Linux
 
 :::note TODO
 Get someone to write a guide to installing a development environment using at least one flavour of Linux
 :::
 
-## Windows
+### Windows
 
 :::note TODO
 Get someone to write a guide to installing a development environment using Windows

--- a/docs/gettingstarted/requirements.md
+++ b/docs/gettingstarted/requirements.md
@@ -9,11 +9,13 @@ Five database types are supported, and several versions of PHP.
 ## PHP
 
 Moodle 4.0 supports the following PHP versions:
+
 - 7.3
 - 7.4
 - 8.0
 
 The following PHP extensions are required (most of which are installed and enabled by default in most PHP installations):
+
 - [iConv],
 - [mbstring],
 - [curl],
@@ -35,6 +37,7 @@ The following PHP extensions are required (most of which are installed and enabl
 ## Relational Database
 
 The following relational database servers are supported. The relevant PHP extension will also be required.
+
 - [MariaDB][mariadb] (version 10.2.29 or higher) with the [MySQLi PHP Extension][php.mysqli]
 - [MySQL][mysql] (version 5.7 or higher) with the [MySQLi PHP Extension][php.mysqli]
 - [Postgresql][postgres] (version 10 or higher) with the [pgsql PHP Extension][php.pgsql]

--- a/docs/gettingstarted/setup.md
+++ b/docs/gettingstarted/setup.md
@@ -5,6 +5,7 @@ title: Setup and installation
 ## Technical requirements
 
 Before installing Moodle you must:
+
 - Install [PHP 7.3.0][php] or higher, and the following PHP extensions (most of which are installed and enabled by default in most PHP installations):
  [iConv],
  [mbstring],

--- a/docs/guides/javascript/index.md
+++ b/docs/guides/javascript/index.md
@@ -326,7 +326,7 @@ A lot of this content is being migrated to use Mustache Templates which are the 
 Where content is generated in PHP you will need to include your JavaScript at the same time.
 
 Although several older ways to include JavaScript from PHP, it`s strongly
-recommended that all new JavaScript only use the `js_call_amd` function on the
+recommended that all new JavaScript only use the`js_call_amd` function on the
 `page_requirements_manager`.
 This has a similar format to the version used in Templates:
 
@@ -369,7 +369,6 @@ export const init = ({courseid, category}) => {
 </TabItem>
 </Tabs>
 
-
 :::caution
 A limit applies to the length of the parameters passed in the third argument.
 If data is already available elsewhere in the DOM, you shoudl avoid passing it as a parameter.
@@ -383,9 +382,9 @@ like full Objects.
 
 Moodle provides several ways to achieve this:
 
-* you can pass a small amount of data into the module initialisation, but this is no longer recommended
-* you can store this data in the DOM as a data attribute which is fetched in your code
-* a Moodle Web Service can be used to fetch more complex data structures dynamically
+- you can pass a small amount of data into the module initialisation, but this is no longer recommended
+- you can store this data in the DOM as a data attribute which is fetched in your code
+- a Moodle Web Service can be used to fetch more complex data structures dynamically
 
 ### Using data attributes
 
@@ -507,7 +506,6 @@ npm -g install grunt-cli
 </Tabs>
 
 #### Using grunt
-
 
 <Tabs>
 <TabItem value="npx_grunt" label="NPX">

--- a/docs/guides/moodleapp/index.md
+++ b/docs/guides/moodleapp/index.md
@@ -13,5 +13,4 @@ We suggest that you read the [Moodle App Overview](./moodleapp/overview) before 
 - Do you want to customise your site in the app? Read the [[Moodle App Customisation]] page.
 - Do you want to make a custom app? Read the [[Custom Moodle Apps]] page.
 
-
 If you have any further questions, check out the [FAQ](#). If there's anything you want to share, you can do it in [the forum](https://moodle.org/mod/forum/view.php?id=7798) or [the Telegram developer room](#). You can also report any bugs that you find in [the tracker](https://tracker.moodle.org/browse/MOBILE).

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -35,7 +35,6 @@ useful:
 - Look at our requeted features
 ```
 
-
 ### Issues
 
 ### Bugs

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -2,8 +2,6 @@
 title: Release notes
 ---
 
-# Release notes
-
 :::note
 This page contains release notes for the upcoming version of Moodle.
 :::

--- a/docs/tools/mdk.md
+++ b/docs/tools/mdk.md
@@ -5,6 +5,7 @@ title: Moodle Development Kit
 Moodle Development Kit, or MDK as it's typically known, is a set of tools,
 written in Python, and maintained by Moodle HQ. It includes helpers for common
 operations including:
+
 - creating new Moodle installations;
 - configuring individual installations;
 - setting up and running phpunit;

--- a/general/community/channels.md
+++ b/general/community/channels.md
@@ -3,19 +3,19 @@ title: Support channels
 slug: /channels
 ---
 
-# The Moodle Community
+## The Moodle Community
 
 Moodle has a huge community with users and contributors across the globe.
 
-## Community forums
+### Community forums
 
-## Developer chat
+### Developer chat
 
 The Official Moodle Developer chat is currently hosted using [Telegram Messenger](https://telegram.org).
 
-You can be a part of the conversation by joining the [#moodledev](https://telegram.me/moodledev) channel. 
+You can be a part of the conversation by joining the [#moodledev](https://telegram.me/moodledev) channel.
 
-### Developer chat policies
+#### Developer chat policies
 
 **Don't use the chat to get support for using Moodle**
 
@@ -24,9 +24,10 @@ There are moodle.org forums for that, or talk to a Moodle Partner
 **Be nice**
 
 Help us maintain a great developer community:
-* Be respectful to others' viewpoints.
-* Give and accept the constructive feedback and eventually criticism, too.
-* Be honest, but not offensive.
+
+- Be respectful to others' viewpoints.
+- Give and accept the constructive feedback and eventually criticism, too.
+- Be honest, but not offensive.
 
 **Speak English in the chat.**
 
@@ -45,4 +46,3 @@ Everything you post in the chat, hits several hundreds of other people instantly
 There are better places online for sharing them.
 
 **Advertising is generally not allowed, although certain exceptions may be made.**
-

--- a/general/community/intro.md
+++ b/general/community/intro.md
@@ -30,7 +30,7 @@ Component leads decide on features in individual components so make your case to
 
 Moodle major releases (with big new features) are on a regular 6 month cycle, in  May and November, since Moodle 2.6. Each major release increments the version number by 0.1 (eg 3.4 -> 3.5 -> 3.6)) and starts a new branch of minor releases.
 
-Minor releases (with bug fixes only) are on a 2 month cycle, unless a security emergency occurs. They will increment the major release by 0.0.1 (eg 3.5 -> 3.5.1 -> 3.5.2).   
+Minor releases (with bug fixes only) are on a 2 month cycle, unless a security emergency occurs. They will increment the major release by 0.0.1 (eg 3.5 -> 3.5.1 -> 3.5.2).
 
 The full details of these can be seen in the [[Releases]].
 
@@ -58,17 +58,17 @@ See our [Process](./development/process.md) document for full information on our
 
 ## Coding Standards
 
-Over time we have distilled our best practice in writing code down into our [[Coding|Coding Guide]].  These rules cover the formatting and layout of all our code to make it consistent across the code base. If you plan to write Moodle code, you need to read it thoroughly. 
+Over time we have distilled our best practice in writing code down into our [[Coding|Coding Guide]].  These rules cover the formatting and layout of all our code to make it consistent across the code base. If you plan to write Moodle code, you need to read it thoroughly.
 
 ## Plugins and APIs
 
-Although Moodle is open source and you can change anything you want, the best and most maintainable way to extend Moodle is to write a plugin (sometimes called a module). Plugins are a directory of code that can be simply "dropped" in into any Moodle installation and it will be detected, installed and automatically made available as a tool within the Moodle interface. 
+Although Moodle is open source and you can change anything you want, the best and most maintainable way to extend Moodle is to write a plugin (sometimes called a module). Plugins are a directory of code that can be simply "dropped" in into any Moodle installation and it will be detected, installed and automatically made available as a tool within the Moodle interface.
 
 See our [[Plugins|Plugin documentation]] for full details of the various types of plugin available.
 
 ## See also
 
-* [[Finding your way into the Moodle code]]
-* [[Working with the Community]]
-* [[Plugin contribution]]
-* [How to guarantee your change is integrated to Moodle core](http://www.slideshare.net/poltawski/how-to-guarantee-your-change-is-integrated-to-moodle-core) presentation by Dan Poltawski 
+- [[Finding your way into the Moodle code]]
+- [[Working with the Community]]
+- [[Plugin contribution]]
+- [How to guarantee your change is integrated to Moodle core](http://www.slideshare.net/poltawski/how-to-guarantee-your-change-is-integrated-to-moodle-core) presentation by Dan Poltawski

--- a/general/community/meetings.md
+++ b/general/community/meetings.md
@@ -12,10 +12,13 @@ Developer meetings are open to anyone interested in Moodle development.
 Next meeting: [[Developer meeting April 2022]]
 
 ## Past meeting notes
+
 ### 2022
+
 - [February 2022](./meetings/202202)
 
 ### 2021
+
 - [[Developer meeting December 2021]]
 - [[Developer meeting October 2021]]
 - [[Developer meeting August 2021]]
@@ -24,14 +27,16 @@ Next meeting: [[Developer meeting April 2022]]
 - [[Developer meeting February 2021]]
 
 ### 2020
+
 - [[Developer meeting December 2020]]
 - [[Developer meeting October 2020]]
 - [[Developer meeting August 2020]]
 - [[Developer meeting June 2020]]
 - [[Developer meeting April 2020]]
--  [[Developer meeting January 2020]]
+- [[Developer meeting January 2020]]
 
 ### 2019
+
 - [[GlobalMoot DevJam Unconference November 2019]]
 - [[Developer meeting October 2019]]
 - [[Developer meeting July 2019]]
@@ -42,22 +47,26 @@ Next meeting: [[Developer meeting April 2022]]
 - [[Developer meeting January 2019]]
 
 ### 2018
+
 - [[Developer meeting December 2018]]
 - [[Developer meeting November 2018]]
 - [[Developer meeting July 2018]]
 
 ### 2017
+
 - [https://devpad.moodle.org/p/mootus17 Miami DevJam November 2017]
 - [[Mannheim DevJam June 2017]]
 - [[London hackfest April 2017]]
 
 ### 2016
+
 - [[Developer meeting September 2016|September 2016 meeting]]
 - [[Developer meeting May 2016|May 2016 meeting]]
 - [[London hackfest March 2016]]
 - [[Developer meeting February 2016|February 2016 meeting]]
 
 ### 2015
+
 - [[Developer meeting October 2015|October 2015 meeting]]
 - [[Minneapolis hackfest August 2015]]
 - [[Developer meeting July 2015|July 2015 meeting]]
@@ -67,6 +76,7 @@ Next meeting: [[Developer meeting April 2022]]
 - [[Developer meeting January 2015|January 2015 meeting]]
 
 ### 2014
+
 - [[Developer meeting October 2014|October 2014 meeting]]
 - [[Developer meeting July 2014|July 2014 meeting]]
 - [[Developer meeting April 2014|April 2014 meeting]]
@@ -74,12 +84,14 @@ Next meeting: [[Developer meeting April 2022]]
 - [[Developer meeting January 2014|January 2014 meeting]]
 
 ### 2013
+
 - [[Developer meeting October 2013|October 2013 meeting]]
 - [[Developer meeting July 2013|July 2013 meeting]]
 - [[Developer meeting April 2013|April 2013 meeting]]
 - [[Developer meeting February 2013|February 2013 meeting]]
 
 ### 2012
+
 - [[Developer meeting November 2012|November 2012 meeting]]
 - [[Perth Hackfest October 2012]]
 - [[Developer meeting August 2012|August 2012 meeting]]
@@ -88,21 +100,25 @@ Next meeting: [[Developer meeting April 2022]]
 - [https://docs.google.com/document/d/1inDtTN5MyCs-o1CGmZoRxSo-n1KsIKExQQaUN4kw9Zo/edit Belgium 2012 hackfest]
 
 ### 2011
+
 - [[Developer meeting November 2011|November 2011 meeting notes]]
 - [[Developer meeting August 2011|August 2011 meeting notes]]
 - [[Developer meeting May 2011|May 2011 meeting notes]]
 
 ### 2010
+
 - [[Developer meeting November 2010|November 2010 meeting notes]]
 - [[Developer meeting May 2010|May 2010 meeting notes]]
 
 ### 2009
+
 - [[Czech Hackfest 2009 notes]]
 - [[Developer meeting September 2009|September 2009 meeting notes]]
 - [[Developer meeting April 2009|April 2009 meeting notes]]
 - [[Developer meeting January 2009|January 2009 meeting notes]]
 
 ### 2008
+
 - [[Developer meeting November 2008|November 2008 meeting notes]]
 - [[Developer meeting September 2008|September 2008 meeting notes]]
 - [[SF Developer HackFest|San Francisco 2008 Developer HackFest]]
@@ -110,10 +126,12 @@ Next meeting: [[Developer meeting April 2022]]
 - [[Developer meeting February 2008|February 2008 meeting notes]]
 
 ### 2007
+
 - [[MoodleMoot 2007 HackFest|UK 2007 MoodleMoot HackFest]]
 - [[Developer conference April 2007|April 2007 meeting notes]]
 
 ### 2006
+
 - [[Developer conference December 2006|December 2006 meeting notes]]
 - [[Developer conference May 2006|May 2006 meeting notes]]
 - [[Developer conference February 2006|February 2006 meeting notes]]

--- a/general/community/meetings/202202.md
+++ b/general/community/meetings/202202.md
@@ -4,9 +4,9 @@ tags:
   - Developer meetings
 ---
 
-# Developer meeting - February 2022
+## Developer meeting - February 2022
 
-## Details
+### Details
 
 This meeting was held on Tuesday 15th February 2022, at 08:00 UTC.
 
@@ -14,7 +14,8 @@ A recording of the meeting is available to
 [watch](https://moodle.org/mod/bigbluebuttonbn/view.php?id=8596), and you can
 [read the discussion](https://moodle.org/mod/forum/discuss.php?d=431482).
 
-## Agenda
+### Agenda
+
 1. Moodle LMS HQ update - [Sander Bangma](https://moodle.org/user/view.php?id=2356736&course=5), Moodle HQ - [[:File:Community Dev Meeting - LMS Update - Feb 2022.pdf|slides PDF]]
 1. The Component Library in Moodle 4.0 - [Bas Brands](https://moodle.org/user/view.php?id=907814&course=5), Moodle HQ
 

--- a/general/community/research.md
+++ b/general/community/research.md
@@ -8,6 +8,7 @@ This page describes why Moodle is used for educational research and what researc
 ## How Moodle Supports Research
 
 There are a number of reasons Moodle is chosen as a platform for educational research.
+
 - **Aligned with academic ethos**<br/>The open source nature of Moodle, as a software project and community, fits well with the transparency needed in academic research.
 - **Extensible for research**<br/>Because Moodle can be customised, it can be used for experiments and data gathering, which would not be as easily conducted in other systems. A plugin created for research on one instance can be shared and used on another system easily.
 - **Common framework**<br/> Because Moodle is freely available and more featured than other Learning Management Systems, it is often chosen as a framework for collaborative research across institutions/organisations. Research conducted on one instance of Moodle, with or without customisations, can be easily replicated on another instance.
@@ -20,6 +21,7 @@ There are a number of reasons Moodle is chosen as a platform for educational res
 ## Moodle research publications
 
 The [Moodle Research Library](http://research.moodle.net) exists as a repository for published research related to Moodle. The repository contains research outputs relevant to the Moodle project and the works of Moodle's community of users.
+
 - Journal articles
 - Conference proceedings papers
 - Papers written to complement MoodleMoot presentations
@@ -39,6 +41,7 @@ Moodle community members come together to share research activities in a person 
 - [Moodle Inspire](https://moodle.org/project_inspire) provides a framework to conduct academic research within Moodle
 
 ## See also
+
 - [[:en:Learning_analytics|Learning analytics]]
 - [[:en:Logging|Logging]]
 - [[Learning_Analytics_Specification|Learning Analytics API specification]]

--- a/general/community/roadmap.md
+++ b/general/community/roadmap.md
@@ -4,52 +4,59 @@ tags:
   - Core development
 ---
 
-# Introduction
+## Introduction
+
 The Moodle Project is designed to have a positive effect on the world by supporting and empowering the educators who are teaching students in all sectors, in all countries.
 
 To do this, our team at Moodle HQ looks to the world, talks with our community, and creates solutions in the forms of products that fit our values of '''education''', '''openness''', '''respect''', '''integrity''' and '''innovation'''.
 
 This document summarises, for a broad audience, the best current plans on the future technical development of the Moodle’s open source learning platform, consisting of Moodle LMS, Moodle Workplace LMS, MoodleCloud, MoodleNet, Moodle Apps, and Moodle Educator Certificates.
-## Where this roadmap comes from
+
+### Where this roadmap comes from
+
 Proposals for improvements and new features come from a variety of different places.
 
 Feedback from the community is extremely important and you can reach us by
-* creating new issues on [tracker](http://tracker.moodle.org),
-* joining the [Moodle Users Association](https://moodleassociation.org/) to vote on a new project for each release,
-* discussing your ideas on the [forums](https://moodle.org/forums),
-* creating new solutions as a plugin in the [Moodle Plugins directory](https://moodle.org/plugins),
-* or meeting us in person at one of our [MoodleMoots](https://moodle.com/events/)
 
+- creating new issues on [tracker](http://tracker.moodle.org),
+- joining the [Moodle Users Association](https://moodleassociation.org/) to vote on a new project for each release,
+- discussing your ideas on the [forums](https://moodle.org/forums),
+- creating new solutions as a plugin in the [Moodle Plugins directory](https://moodle.org/plugins),
+- or meeting us in person at one of our [MoodleMoots](https://moodle.com/events/)
 
 Moodle also has an extensive network of [Moodle Partners](https://moodle.com/partners). Moodle Partners are service providers that are certified by Moodle HQ to provide high quality Moodle services for schools, institutions and organisations. We work closely with our partners to determine the needs of Moodle Users and improve the platform.
 
 Our Roadmap is built via our [[Roadmap process]]. This process is continuously evolving but it always seeks to involve all our key stakeholders - students, teachers, admins, institutions, and of course our partners and supporters.
 
-## The big picture
+### The big picture
+
 Working on the Moodle learning platform involves millions of moving parts, and every release generally includes hundreds of improvements. However, there are '''four main goals''' that we are focussing on for the next two years:
 
-###  User experience and flow
+#### User experience and flow
+
 The entire user experience from onboarding, into daily teaching/learning and expert customisation of Moodle is the core value of what makes Moodle useful or not in the real world, in fully online and blended modes.
 
 While we’re working on hundreds of smaller, annoying issues, we are also doing some major re-thinking around what an LMS should be in the next decade and beyond as a tool to empower educators and learners.
 
-###  Enabling all our developers
+#### Enabling all our developers
+
 Our significant community of engaged developers are an amazing group of over 1000 people - many of them make a living being part of the Moodle community.
 
 We are of course working on ways to make Moodle programming easier and better, with better training and support as well as improved APIs, plugins, integrations and support for modern technologies.
 
 However, a particularly exciting initiative is the new Moodle Plugins Service, due in 2021, which will provide an “app store” experience on which all developers can build financial sustainability for their work, while teachers will have easier access to use hundreds of new plugins in their courses via the web interface, without needing to convince their admins to install code. This will help the entire plugins ecosystem.
 
-### Better integrations between Moodle products
+#### Better integrations between Moodle products
+
 The current Moodle products already integrate with each other, of course, but there is much more to be done to make them work together more seamlessly, as part of one platform, so that our users have a better experience and also so that they become more aware of solutions to their problems.
 
-###  Better integration with the world
+#### Better integration with the world
+
 Moodle is never used alone, and it is a part of many ecosystems at many levels. We must connect to all kinds of other systems, we must of course comply with new legislation such as the GDPR, Accessibility and much more.
 
 In particular though, we are committed to helping to promote [<span class="underline">Open EdTech</span>](https://openedtech.global/) and to work closely with qualified Open EdTech products and major stakeholders to design and build an open architecture for a long-term future.
 
-
-## Roadmap timeline
+### Roadmap timeline
 
 | 2021 | Moodle LMS | Moodle Workplace | Moodle Apps | MoodleCloud | MoodleNet | Moodle Academy |
 | ---  | ---        | ---              | ---         | ---         | ---       | ---            |
@@ -62,9 +69,10 @@ In particular though, we are committed to helping to promote [<span class="under
 |
 |
 |
-* [Moodle.Academy](https://moodle.academy) launched.
 
-* [First Educator courses released](https://moodle.academy/mod/page/view.php?id=57&forceview=1).
+- [Moodle.Academy](https://moodle.academy) launched.
+
+- [First Educator courses released](https://moodle.academy/mod/page/view.php?id=57&forceview=1).
 |-
 | '''Q4'''
 | '''Minor release(s)'''
@@ -74,7 +82,7 @@ In particular though, we are committed to helping to promote [<span class="under
 <br />
 |
 |
-* [Further Educator courses released](https://moodle.academy/mod/page/view.php?id=57&forceview=1).
+- [Further Educator courses released](https://moodle.academy/mod/page/view.php?id=57&forceview=1).
 |-
 | '''2022'''
 | '''Moodle LMS'''
@@ -91,37 +99,34 @@ In particular though, we are committed to helping to promote [<span class="under
 |
 |
 |
-* [First Developer Beginner courses released](https://moodle.academy/mod/page/view.php?id=59&forceview=1).
+- [First Developer Beginner courses released](https://moodle.academy/mod/page/view.php?id=59&forceview=1).
 |-
 | '''Q2'''
 |'''Moodle 4.0'''
 
-
 '''UX improvements'''
-* Navigation
-* Course experience
-* Onboarding
-* Other wins (calendar / timeline block)
-* UI consistency via component library
 
+- Navigation
+- Course experience
+- Onboarding
+- Other wins (calendar / timeline block)
+- UI consistency via component library
 
 '''New:'''
-* LTI 1.3 Advantage Tool / Provider implementation
-* BigBlueButton integration
-* Atto accessibility improvements (MUA)
 
-* Workplace Report Builder integration
-* Site admin presets
+- LTI 1.3 Advantage Tool / Provider implementation
+- BigBlueButton integration
+- Atto accessibility improvements (MUA)
 
+- Workplace Report Builder integration
+- Site admin presets
 
 '''Minor release(s)'''
 | '''Release 4.0'''
 | '''Release 4.0'''
 
-
 '''Improved'''
 Moodle LMS 4.0 compatibility
-
 
 '''Moodle Workplace 4.0 compatibility'''
 
@@ -129,15 +134,15 @@ Classroom tools with friendly UX
 | '''Release 4.0'''
 |
 |
-* [Further Educator courses released](https://moodle.academy/mod/page/view.php?id=57&forceview=1)*.
-* [First Administrator courses released](https://moodle.academy/mod/page/view.php?id=58&forceview=1)*.
-* [Further Developer courses released](https://moodle.academy/mod/page/view.php?id=59&forceview=1)*.
-* Learn Moodle courses migrated to [Moodle.Academy](https://moodle.academy).
-* Program certificates available for purchase.
-* Translations in languages other than English.
 
+- [Further Educator courses released](https://moodle.academy/mod/page/view.php?id=57&forceview=1)*.
+- [First Administrator courses released](https://moodle.academy/mod/page/view.php?id=58&forceview=1)*.
+- [Further Developer courses released](https://moodle.academy/mod/page/view.php?id=59&forceview=1)*.
+- Learn Moodle courses migrated to [Moodle.Academy](https://moodle.academy).
+- Program certificates available for purchase.
+- Translations in languages other than English.
 
-<nowiki>*</nowiki>A course in each learning pathway (Educator, Administrator, Developer) will introduce changes in Moodle 4.0.
+\* A course in each learning pathway (Educator, Administrator, Developer) will introduce changes in Moodle 4.0.
 |-
 | '''Q3'''
 |'''Minor release(s)'''
@@ -150,17 +155,17 @@ Classroom tools with friendly UX
 | '''Q4'''
 | '''Moodle 4.1'''
 
-
 '''UX improvements'''
-* Course activities
-* Gradebook
-* Global UX (tables/filters)
 
+- Course activities
+- Gradebook
+- Global UX (tables/filters)
 
 '''New'''
-* Improved integration with MoodleNet and other Moodle sites
-* Improved integration with 3rd party platforms/tools
-* Database improvements (MUA)
+
+- Improved integration with MoodleNet and other Moodle sites
+- Improved integration with 3rd party platforms/tools
+- Database improvements (MUA)
 |
 | '''Release 4.1'''
 | '''Release 4.1'''
@@ -168,34 +173,39 @@ Classroom tools with friendly UX
 |
 |}
 
-##  Notes on the Moodle LMS releases
+### Notes on the Moodle LMS releases
 
-### Moodle 4.0 in April 2022
+#### Moodle 4.0 in April 2022
+
 For our very large new releases such as 1.0, 2.0, 3.0 and now 4.0, we often take longer so that we can tackle more significant chunks of important core work, giving us the opportunity sometimes to make more serious changes to UX or architecture. Moodle 4.0 will focus on UX improvements.
 
 As part of a significant UX and design change, the current focus is on three main UX projects:
-* [[Moodle_4.0_navigation_improvements|Improved navigation]], search and menus - MDL-69588
-* Making it easier to create and manage courses - MDL-70907
-* Making it easier for students to know what they need to do to complete a course, and know what’s next
 
+- [[Moodle_4.0_navigation_improvements|Improved navigation]], search and menus - MDL-69588
+- Making it easier to create and manage courses - MDL-70907
+- Making it easier for students to know what they need to do to complete a course, and know what’s next
 
 Other projects include:
-* LTI 1.3 Advantage Tool / Provider implementation - MDL-69542
-* BigBlueButton integration - MDL-70658
-* a community proposal for the question bank being discussed and shaped by a consortium of universities - [[Question bank improvements for Moodle 4.0]].
-* Integration of the [admin presets](https://moodle.org/plugins/block_admin_presets) tool to enable saving, loading, and sharing of Moodle site configurations - [[Site admin presets]].
 
-###  Moodle 3.11
+- LTI 1.3 Advantage Tool / Provider implementation - MDL-69542
+- BigBlueButton integration - MDL-70658
+- a community proposal for the question bank being discussed and shaped by a consortium of universities - [[Question bank improvements for Moodle 4.0]].
+- Integration of the [admin presets](https://moodle.org/plugins/block_admin_presets) tool to enable saving, loading, and sharing of Moodle site configurations - [[Site admin presets]].
+
+#### Moodle 3.11
+
 In 2021 the majority of HQ developers will be focused on the UX improvements that are scheduled for Moodle 4.0. This means that the Moodle 3.11 release is anticipated to contain mostly community contributed improvements and a couple smaller HQ developments.
 
 Note that while we will endeavour to include all community contributions in the 3.11 release, we may defer some improvements to a later release depending on the complexity, size, and impact on other scheduled work.
 
 Scheduled projects for Moodle 3.11 are:
-* [[Student activity completion]] (MUA) - MDL-70469
-* Open Badges v2.1 (Badge Connect API) - MDL-71117
-* Brickfield accessibility toolkit integration - MDL-71041
 
-###  Release support timeframes
+- [[Student activity completion]] (MUA) - MDL-70469
+- Open Badges v2.1 (Badge Connect API) - MDL-71117
+- Brickfield accessibility toolkit integration - MDL-71041
+
+#### Release support timeframes
+
 We are extending security support on Moodle 3.9 and Moodle 3.11 to November 2023. We are also extending general bug fix support on Moodle 3.11 by 6 months to November 2022. This will provide additional support and time for sites to make the transition to Moodle 4.0 or Moodle 4.1.
 {| class="wikitable" border="1"
 |-
@@ -230,11 +240,13 @@ We are extending security support on Moodle 3.9 and Moodle 3.11 to November 2023
 | Nov 2025
 |}
 
-# Past releases
+## Past releases
+
 See our [[Releases]] page for information about past releases.
 
 After Moodle 2.0 we switched to time-based releases rather than feature-based releases (see our [development process](../development/process.md)). Because of this, the details above on future releases are an indication of current priorities only, and are targeted to be released in the upcoming releases. Anything not ready by the next release date will generally be pushed to the following major release.
 
-## See also
-* [[Releases]] - versions of Moodle that have already been released
-* [[Releases#General_release_calendar|Key dates relating to future releases]]
+### See also
+
+- [[Releases]] - versions of Moodle that have already been released
+- [[Releases#General_release_calendar|Key dates relating to future releases]]

--- a/general/development/policies/codingstyle/index.md
+++ b/general/development/policies/codingstyle/index.md
@@ -580,9 +580,11 @@ class core_user_example {
 The use of namespaces must conform to the following rules:
 
 1. Classes belonging to a namespace must be created in a classes directory, for example:
-  - in the `mod_forum` plugin classes should be placed in `mod/forum/classes`;
-  - for core code, classes should be placed in `lib/classes`; or
-  - for a core subsystem, classes should be placed in `subsystemdir/classes`.
+
+- in the `mod_forum` plugin classes should be placed in `mod/forum/classes`;
+- for core code, classes should be placed in `lib/classes`; or
+- for a core subsystem, classes should be placed in `subsystemdir/classes`.
+
 1. The classname and filename for all namespaced classes must conform to the [[Automatic class loading|automatic class loading]] rules. The use of formal PHP namespaces is **required** in all new code.
 1. Use at most one namespace declaration per file.
 
@@ -751,16 +753,14 @@ Nested namespaces are used when the class implements some core API or when the p
 
 The first level, when used, **MUST** be _either_:
 
-- a full component name (for example `\mod_forum`).
-  All classes using namespaces in a plugin *MUST* be contained in this level 1
-  namespace; or
+- a full component name (for example `\mod_forum`). All classes using namespaces in a plugin *MUST* be contained in this level 1 namespace; or
 - `\core` for all core apis
 
 #### Rules for level2
 
 The second level, when used, **MUST** be _either_:
 
-- The short name of a [core API](/docs/apiguides). 
+- The short name of a [core API](/docs/apis).
   The classes in this namespace must either implement or use the API in some way; or
 - `\local` for any other classes in a component, if the maintainer wants to organise them further (note that for most components, it's probably enough to have all their own classes in the root level1 namespace only).
 
@@ -995,7 +995,6 @@ $myarray = [1, 2, 3, 'Stuff', 'Here',
 The example above also can be written as follows:<br/>
 (with special attention to the last line having a trailing comma to extend the list of items later with a cleaner diff)
 
-
 <ValidExample>
 
 ```php
@@ -1143,7 +1142,6 @@ Always use the `else if` variant
 
 :::
 
-
 Always use braces (even if the block is one line and PHP doesn't require it). The opening brace of a block is always placed on the same line as its corresponding statement or declaration.
 
 <ValidExample>
@@ -1209,6 +1207,7 @@ Whitespace must be used around the operators to make it clear where the operatio
 $username = isset($user->username) ? $user->username : *; **
 $users = is_array($users) ? $users : [$users];
 ```
+
 </ValidExample>
 
 <InvalidExample>
@@ -1367,6 +1366,7 @@ The `@var` tag is used to document class properties.
 ```
   @var [[#Types|type]] Description.
 ```
+
 </ValidExample>
 
 Exceptionally, when none of the available [[#Types|types]] define the returned value, inline @var phpdocs (within the body of the methods) providing type hinting are allowed to the returned type. Don't abuse!
@@ -1380,6 +1380,7 @@ If a function uses die or exit, please add this tag to the docblock to help deve
 ```
   @uses exit
 ```
+
 </ValidExample>
 
 ##### `@access`
@@ -1394,6 +1395,7 @@ The access can be used to specify access control for an element
 ```
   @access private
 ```
+
 </ValidExample>
 
 ##### `@package`

--- a/general/development/policies/component-communication/index.md
+++ b/general/development/policies/component-communication/index.md
@@ -8,41 +8,41 @@ tags:
 
 import { CodeBlock, TabItem, Tabs } from '@site/src/components';
 
-## Components 
+## Components
 
 ![Components in Moodle](./componentsinmoodle.png)
 
 Moodle is code is split into different sections called `components`.
 
-### Core 
+### Core
 
 The core libraries provide the base functionality that all other parts of moodle rely on. The component for core libraries is just referred to as `core`. Core code is not optional and cannot be safely removed without breaking Moodle. This means that it is always available and can be safely called from anywhere. Core code sits directly in the `/lib/` folder, or in the `/lib/classes/` folder for autoloaded core classes.
 
-### Subsystems 
+### Subsystems
 
 Subsystems are groups of related functions and classes that are part of core, but are logically grouped together. Often they are tied to a particular feature in Moodle, and sometimes can be disabled/enabled via a single config setting - but the code is never removed. It is safe to call core subsystems from anywhere in Moodle - but the functions may return an error to indicate that a feature has been disabled. Each core subsystem has a defined location where its code is grouped together. As of Moodle 3.1 there are 66 subsystems in core and the comprehensive list can be found here:
 
 core_component::fetch_subsystems()
 
-### Plugins 
+### Plugins
 
 Plugins are optional components in Moodle that extend its functionality. M in Moodle stands for `Modular` and most of the code in Moodle belongs to plugins. There are many different types of plugins, and each plugin type supports a different way to extend core functionality. Information on the available plugins types in Moodle can be found here:
 
-### Plugin Types 
+### Plugin Types
 
 Vanilla Moodle package contains over 370 plugins. Additional plugins can be downloaded from the Plugins directory, or installed manually - and all plugins in Moodle are considered `optional`, even the ones included in vanilla package. This means that you can never assume a particular plugin will always exist on every Moodle site.
 
-### Sub-plugins 
+### Sub-plugins
 
 Some plugin types in Moodle support sub-plugins. This means that they can use other plugins to extend their own functionality. The only plugin types in Moodle that allow this are activity modules, editors, administration tools and local plugins. A sub-plugin can assume that its parent plugin is installed and does exist in Moodle - and can call its code directly, but it cannot assume anything about any other plugin or sub-plugin in Moodle.
 
-### Dependencies 
+### Dependencies
 
 Some plugins in Moodle depend on other plugins. An example of a dependency relationship is a plugin that `hosts` sub-plugins - each of the sub-plugins depends on the parent. Another example is where the dependency is explicitly defined in the version.php of the plugin.
 
 ![Component dependencies](./componentdependencies.png)
 
-## Communication Channels 
+## Communication Channels
 
 There are different ways to call code in Moodle. Most of them are listed here and described in detail later on:
 
@@ -54,52 +54,53 @@ There are different ways to call code in Moodle. Most of them are listed here an
 - Event observers
 - Component callbacks
 
-## General rules for inter-component communications 
+## General rules for inter-component communications
 
 Because all plugins are optional, we can never rely on a plugin being installed in Moodle, unless there is a dependency relationship between the current component and the plugin. Core components and subsystems are always installed.
 This means there are some strict rules about which types of communication are allowed in Moodle.
 
-* It is always allowed to communicate with a `required` component. This includes core and all its subsystems.
-* Any component is allowed to communicate with itself.
-* It is allowed to communicate with another component if the calling component `depends` on the other component (see description of dependencies above).
-* Not shown in the diagram - but the same rules apply to sub-plugins. They can communicate with their parent and any plugin that they explicitly (version.php) depend on.
-* All other inter-component communications are forbidden.
+- It is always allowed to communicate with a `required` component. This includes core and all its subsystems.
+- Any component is allowed to communicate with itself.
+- It is allowed to communicate with another component if the calling component `depends` on the other component (see description of dependencies above).
+- Not shown in the diagram - but the same rules apply to sub-plugins. They can communicate with their parent and any plugin that they explicitly (version.php) depend on.
+- All other inter-component communications are forbidden.
 
 ![Allowed communication](./allowedcommunication.png)
 
-### Direct php function calls 
+### Direct php function calls
 
 This is the simplest type of communication - you know the name of a function so you just call it. Sometimes the name of the function is generated from the component name to allow different plugins to implement the same function with a different prefix or namespace.
 
-### External functions 
+### External functions
 
 External functions are functions defined in Moodle using the External API. These are functions suitable to call from webservices, or call directly from other parts of Moodle. Each external function follows a similar pattern:
 
-* Parse and validate arguments
-* Perform security checks and setup the theme and language (from the context)
-* Call an internal API
-* Return and validate the response
+- Parse and validate arguments
+- Perform security checks and setup the theme and language (from the context)
+- Call an internal API
+- Return and validate the response
 
 Calling external functions from another component in Moodle is no different to calling the php functions directly. This is allowed and encouraged.
 
 One thing to think about when calling external functions from php though is that they are designed to be able to be called from a webservice, and so they will re-do all of the security checks and setup of the page theme and language that you have probably already done in your php page. To make sure this doesn’t cause side-effects (like changing the theme halfway through a page), always use the wrapper in `external_api::call_external_function()` instead of calling the external function directly.
 
 Additional rules for calling external functions:
-* Always use the external_api::call_external_function() wrapper when calling from php.
 
-### Javascript Modules (AMD) 
+- Always use the `external_api::call_external_function()` wrapper when calling from php.
+
+### Javascript Modules (AMD)
 
 It is possible through the Javascript loader to load an AMD module from any component and call its functions. This is a form of inter-component communication and must obey the strict rules for which components AMD modules can be loaded from.
 
-### get_string 
+### get_string
 
 It is possible to fetch strings from any component in Moodle. This is a form of inter-component communication and and must obey the strict rules for which components strings can be fetched from.
 
-### Templates (Mustache) 
+### Templates (Mustache)
 
 It is possible to fetch templates from any component in Moodle. This is a form of inter-component communication and and must obey the strict rules for which components templates can be fetched from.
 
-### Event observers 
+### Event observers
 
 Any action in Moodle can trigger one or more `events`.
 
@@ -108,106 +109,97 @@ In Moodle it is possible to register observers for events. An observer is notifi
 In addition - event observers are a form of execution at a distance. It would be extremely difficult to read and maintain code heavily relying on event observers (especially if the observers perform actions that trigger more events).
 
 Additional rules for event observers:
-* Events are not allowed to be observed by core or a core subsystem (there are some currently wrong observers in core that should be removed).
 
-### Callback methods (component_callback, get_plugins_with_function…) 
+- Events are not allowed to be observed by core or a core subsystem (there are some currently wrong observers in core that should be removed).
+
+### Callback methods (component_callback, get_plugins_with_function…)
 
 The most common way (but not the only way) to implement a callback is using the `component_callback()` function. This function works by looping over the installed plugins and calling a function from each plugin based on appending the component name to the supplied function name. It then expects the function to be defined either in the plugins lib.php file, or in an autoloaded location (but not in a class!).
 
 [[Callbacks|List of callbacks in Moodle]]
 
-## FAQ 
+## FAQ
 
 **Q: So how does plugin X call a function from plugin Y if they don’t depend on each other?**
 
 A: By communicating through a core API.
 
-
 **Q: What? Really?**
 
 A: Anytime one plugin wants to communicate to one other specific plugin - it’s better to create a core API and channel all communication through that API. For example `assignment online text` uses the `Editor API` to add a rich text field to the form. It does not directly add an instance of `Atto` to the form. This allows either plugin to be replaced by a different, (hopefully better) plugin without changing the API or the other plugin. Remember, any plugin in Moodle is optional and may be removed in the future.
-
 
 **Q: How do I know if there is an API I can already use?**
 
 A: Existing callbacks are listed [[Callbacks|here]], major core APIs are listed [[Core_APIs|here]].
 
-
 **Q: Can I change the data provided to a component_callback and maintain backwards compatibility.**
 
 A: No it is not possible. You must implement a second callback with a new name.
-
 
 **Q: Can I control the order in which plugins callbacks are executed?**
 
 A: No it is not possible.
 
-
 **Q: Can I find all the plugins implementing a callback?**
 
 A: You can grep the code or create a test script that executes `get_plugins_with_function()`
-
 
 **Q: How can I ensure the name for my new callback is unique?**
 
 A: Check [[Callbacks|list of existing callbacks]]. Consider prefixing with the component name the callback is defined in - but existing code does not do this much.
 
-
 **Q: Will my callback function be called even if my plugin is disabled?**
 
 A: Yes - you must manually check if your own plugin is disabled before responding to a component callback.
-
 
 **Q: I looked, there is no existing API I can use. How do I get a new one added to core?**
 
 A: Create a tracker issue, post a patch (with unit tests) and explain your use case.
 
-
 **Q: When should I create a callback and when should I use event observers?**
 
 A: Event observers should not be added to facilitate plugin communication. They are about notifying the system that a real event occurred. Use an event observer only if:
-* There is a real event occurring at the point you need to execute some additional code.
-* You are not cheating the inter-component communication rules.
-* You do not need to modify any of the data related to the event.
+
+- There is a real event occurring at the point you need to execute some additional code.
+- You are not cheating the inter-component communication rules.
+- You do not need to modify any of the data related to the event.
 
 Otherwise add a new callback and execute for each plugin implementing it, using `get_plugins_with_function()`
-
 
 **Q: Can I use one of the broadcast functions to provide a callback to some plugin types, but not all of them?**
 
 A: It is better to allow all plugin types. Previously assumptions have been made about which plugins should be able to respond to an API and they have almost always turned out wrong.
 
-
 **Q: Can create an API with callbacks that supports multiple stages?**
 
 A: Not easily. You must create a separate callback for each stage and hope that consumers of your API create the correct function for each stage. An alternative is to create a callback that is expected to be returned an instance of an abstract class which defines your API.
-
 
 **Q: Global functions are bad. Can I implement a callback in a class instead?**
 
 A: No. Sorry.
 
-## Ideal plugin design 
+## Ideal plugin design
 
 ![Ideal plugin design](./idealplugindesign.png)
 
 When building a new plugin for Moodle - it is good to think about how to best structure the code so that we separate our code into layers of functionality. This way we can provide a secure and comprehensive API that can be called from inside, or outside of our component, or from web-services (like the Mobile App or AJAX).
 
-### Low Level API 
+### Low Level API
 
 In this model, the DB tables are accessed through a low level API that knows about all the types, relationships and validation rules for the data in the tables. No permission checking is done at this level for performance and complexity reasons.
 
-### Component API 
+### Component API
 
 The component API defines all the things this plugin can do. Every function in the API should perform permission checks and validation on the parameters and return types and be covered by unit tests. This is the useful API that can be used by pages in your plugin, or called directly by another component in Moodle (only if it depends on this plugin).
 
-### External API 
+### External API
 
 The external API is a single class that wraps each function in the Component API. By exposing all the functions in the Component API we allow people to build new interfaces and apps that we have never even thought about without requiring changes to our plugin. Covering each external function with a unit test ensures that all our parameters and return types are correctly specified. Note: External API functions can be called directly from other dependant plugins or sub-plugins in Moodle - but you must use the external_api::call_external_function to do so or you will introduce problems with theme, language and context.
 
-### Webservice API 
+### Webservice API
 
 This is not really an API, it is just a listing of all the functions in the external API in our plugins db/services.php file. This allows all these functions to be called from AJAX or webservices clients like the Mobile App.
 
-## Editing images in this doc page 
+## Editing images in this doc page
+
 This page was created from a google doc. To edit the images in this page - re-export them from the original document here: https://docs.google.com/document/d/1Z-vRWztT05bsb9b5KbBpLRP26oa3KTx3thB52_BW5VY/edit#heading=h.ardt51j6brj1

--- a/general/development/process.md
+++ b/general/development/process.md
@@ -11,6 +11,7 @@ tags:
 This document summarises the various development processes used in developing Moodle. There are four main processes that overlap.
 
 ## Integration workflow in the tracker
+
 The Moodle tracker keeps track of the status of all bug fixes and new features.
 
 We use a workflow that ensures that new code receives multiple reviews by different people before it is included into the core Moodle code.
@@ -18,27 +19,38 @@ We use a workflow that ensures that new code receives multiple reviews by differ
 ![A summary of the Moodle Development Process flow](./process/_files/workflow.jpg)
 
 A number of roles make this work:
+
 ### Users
+
 Users report bugs and make feature requests directly in the tracker, by creating new issues with a summary and a description.
+
 ### Developers
-Developers work on the issues in the tracker to specify solutions and write code that implements these solutions. They will often ask other developers to "peer review" their code in the early stages to avoid problems later on.
+
+Developers work on the issues in the tracker to specify solutions and write code that implements these solutions. They will often ask other developers to _peer review_ their code in the early stages to avoid problems later on.
 
 While many of the developers work for Moodle.com, a large number are part of the global development community around Moodle. If you're interested in becoming a recognised developer, see [[Tracker_guide#Tracker_groups_and_permissions|Tracker groups and permissions]].
+
 ### CiBoT
+
 CiBoT is not a person but a bot who monitors the tracker and performs the [[Automated code review]] when issue is submitted for Peer review or when developer added _cime_ label.
+
 ### Component leads
+
 [Component leads](https://tracker.moodle.org/projects/MDL?selectedItem=com.atlassian.jira.jira-projects-plugin:components-page) are developers with some responsibility for particular components (plugins or modules) in Moodle. They have authority to decide that a particular fix is suitable and complete enough to be considered for integration in Moodle core and should be called upon to complete peer reviews for code in their components. Note that, apart from that, every component also has some [[Component Leads|HQ Component leads]] that will specifically work on associated issues, triaging, monitoring, reviewing, fixing them.
 
 ### Component leads reviewers
+
 Component Lead Reviewers are Component Leads who have the added responsibility of performing a second and final review of a selection of issues within their component.
 After reviewing the code, it is sent to the integration team to be pulled without further review.
 
 ### Integrators
+
 From Monday to Thursday, the integration team (a small team of senior developers employed by Moodle HQ) conducts a code-level review of all issues in the integration queue. This is often called the "pull" process. If the fix is judged appropriate they will integrate the code into our git integration repository for further testing and it gets added to the testing queue.
 
 If they find problems they reject the issue and send it back to the developer for further work.
 
 ### Testers
+
 During each week the testers look at all the issues in the testing queue, trying each fix and feature to make sure that it does actually fix the problem it was supposed to, and that there are no regressions in the web version and the Moodle mobile app.
 
 If they find problems they reject the issue and integrators may remove it from the integration repository and push it back to the developer for further work.
@@ -46,24 +58,31 @@ If they find problems they reject the issue and integrators may remove it from t
 See [[Testing of integrated issues]] for more details.
 
 ### Production maintainers
+
 On Thursday each week, production maintainers merge all the issues that passed testing into the git production repository, and it becomes available for use on production systems via git and download packages.
+
 ## Stable maintenance cycles
+
 Moodle releases regular updates of the stable version of the software to fix bugs and other issues. Releases like 2.2.1, 2.2.2, 2.2.3 etc only include fixes based on the latest major release (2.2) and never any significant new features or database changes.
 
 At Moodle HQ there are teams of developers using the [Scrum framework](http://www.scrum.org/) to work on these issues (as well as new features for [[#Major_release_cycles|major releases]]).
 
 ### Minor release (point release) timing
+
 After [[#Major_release_cycles|major releases]] there will be minor releases.
-* x.x.1 will occur approximately two months after each major release (eg. 2.x).
-* There will then be another point release every two months after that.
+
+- x.x.1 will occur approximately two months after each major release (eg. 2.x).
+- There will then be another point release every two months after that.
 See the [[Releases#General_release_calendar|General release calendar]] for details.
 
 ### Issue triage
-[[Bug_triage|Issue triage]] involves evaluating new issues, making sure that they are recorded correctly. One of the most important jobs triagers do is to identify issues that should be fixed in the stable branch. These are set with a priority ranging from "Trivial" up to "Blocker" and other features are checked.
+
+[[Bug_triage|Issue triage]] involves evaluating new issues, making sure that they are recorded correctly. One of the most important jobs triagers do is to identify issues that should be fixed in the stable branch. These are set with a priority ranging from _Trivial_ up to _Blocker_ and other features are checked.
 
 At Moodle HQ there are currently teams working on stable issues (mostly bugs reported by users) and improvements and new features (Partners, Moodle Association, user suggestions and Martin Dougiamas).
 
 ### Scrum
+
 At Moodle HQ, every three weeks, the stable team takes a number of the most urgent issues from the backlog to work on during a period known as a _sprint_.
 
 At the start of a sprint there is a period of planning and estimation. All issues on the backlog are given a relative rank that is based on issue features including priority, security, Partner interest, patches and votes. Issues are given a relative size in Story Points and these points are summed to allow the teams to determine how many issues they can work on in the sprint.
@@ -73,28 +92,39 @@ During the sprint, the team meets daily to discuss solutions and progress, as we
 Whenever a solution for an issue is finished, it is submitted to the standard integration workflow process described above.
 
 ## Major release cycles
+
 Since Moodle 2.0, we have a policy of release major versions (eg 2.1, 2.2) every six months in May and November. See the [[Releases#General_release_calendar|General release calendar]] for more details.
 
 Each release can be different, but generally the cycles work as follows.
+
 ### Define roadmap
+
 The roadmap is prioritised based on user research, stakeholder inputs, community wishes, third-party developments and important issues within the existing code.
 
 Sometimes new features might be based on earlier features, sometimes they may be something developed by a third party that needs to be evaluated and sometimes it might be something completely new.
+
 ### Planning and development
+
 The product teams together with UX, employed at Moodle HQ, work on specifications of major new features throughout the cycle, specifying projects ahead of development time.
 
 The process of [[#New_feature_development|new feature development]] is described below. When specifications are in place, new code is developed during sprints, where designs and implementation are iterated as required, and goes through the standard weekly integration workflow described above.
+
 ### Testing
+
 During development, as new code is integrated, automated testing conducted at the [[PHPUnit|code]] and [[Acceptance_testing|interface]] levels, to make sure there are no regressions caused by new features.
 
-In the last month before the release, a feature freeze is called (no new features can be added) and volunteer testers from the Moodle community perform manual QA testing of Moodle features. The current set of functional tests is listed in MDLQA-1. The list of tests is extended as new features are added, though we're also trying to reduce the number as more automated [[Acceptance_testing|acceptance tests]] are developed.
+In the last month before the release, a feature freeze is called (no new features can be added) and volunteer testers from the Moodle community perform manual QA testing of Moodle features. The current set of functional tests is listed in {tracker}`MDLQA-1`. The list of tests is extended as new features are added, though we're also trying to reduce the number as more automated [[Acceptance_testing|acceptance tests]] are developed.
 
-There is also a set of tests for manually testing any major theme changes - MDLQA-11592.
+There is also a set of tests for manually testing any major theme changes - {tracker}`MDLQA-11592`.
 
 For more details, see [[Testing]].
+
 ### Sprints
+
 At Moodle HQ, development takes place in sprints. The sprints are two or three-week periods during which developers to focus on a fixed list of issues. For example, sprints can be arranged within each release cycle as shown in the diagram below.
+
 ### Events during cycle
+
 During each cycle there are a periods and events that occur between and around sprints.
 
 ![The Development sprint calendar](./process/_files/sprintcalendar.png)
@@ -110,9 +140,13 @@ During each cycle there are a periods and events that occur between and around s
 : A period after the code freeze where quality assurance testing takes place. No new code is added, which means developers are able to respond rapidly to bugs found. Integration becomes [[Integration Review#During continuous integration/Freeze/QA period|continuous]], meaning that failed QA tests can be re-run within days rather than having to wait for the weekly release.
 ; *Release candidate*
 : A point prior to the full release where a candidate is made public for wider testing.
+
 ## New feature development
+
 Major new features in Moodle usually should go through the following process.
+
 ### Specification
+
 The User Experience (UX) team members create detailed wireframes and features and goals for the new feature, based on iterative user research, design sprints, user testing and co-design as part of the product team.
 
 For bigger features there should be a clear overall vision for the outcomes that are to achieved. During implementation design may continue to iterate based on new findings.
@@ -120,102 +154,140 @@ For bigger features there should be a clear overall vision for the outcomes that
 Developers create a detailed spec (here in the developer docs) outlining their goals for the development and their design for meeting those goals.
 
 Developers should also create an issue in the tracker (linking to your docs) to keep track of the project status.
+
 ### Community consultation
+
 Get the community involved in looking at the spec to see if it meets their needs and to get further feedback. Please post in the [Future major features forum](http://moodle.org/mod/forum/view.php?id=8052) on moodle.org. You could also blog/tweet about it etc.
 
 Community developers proposing a new feature will want to talk with HQ core developers to make sure the ideas make sense, and possibly get some review on database design, architecture and so on.
+
 ### Develop the code using Git
+
 Develop your code on an open Git repository, like github.com. That enables people to see your code and to help you as it develops. Testers and early adopters also have the opportunity to try it early in the process and give you more valuable feedback.
 
 Coverage with automated tests ([[PHPUnit]] or [[Behat|Behat_integration]]) is mandatory for new features.
 
 It is essential that your code follows the [[Coding|Moodle Coding Guide]].
+
 ### Submit your code for peer review
-Click on "Request peer review" button in the tracker.
+
+Click on _Request peer review_ button in the tracker.
 
 You need to fill in the information about your public git repository and which branches the fixes are on. Make sure you are listed as Assignee.
 
 This would be a good time to fill in the testing instructions (read the [[Testing instructions guide|instructions guide]]) for how to verify your fix is correct. You may also wish to add a comment in the bug.
 
-Component leads should put issues, which affect code in their components, up for peer review to allow interested parties to provide feedback. However, if it is not reviewed in a week, a component lead may send the issue to integration. If integrators consider that the issue has not been given proper chance for peer review (e.g. is extremely large or complex...) it can be decided to move the issue back in the process.
+Component leads should put issues, which affect code in their components, up for peer review to allow interested parties to provide feedback. However, if it is not reviewed in a week, a component lead may send the issue to integration. If integrators consider that the issue has not been given proper chance for peer review (for example is extremely large or complex) it can be decided to move the issue back in the process.
 
 All other developers, including people who are component leads but working outside their component, should have their issues peer reviewed before they are sent to integration.
+
 ### Peer review
+
 The [[HQ component leads]] should peer-review the change. If there is no component lead for an affected component, any other recognised developer may complete the peer review. The peer reviewer will either give you comments on the code and if it needs more work.
 
 Process and the list of things to check are described in [Peer reviewing](process/peer-review).
 
 ### Submit the code for integration
+
 The developer is responsible for acting on the feedback from the peer reviewer. If changes have been made and the developer is satisfied that this has accommodated the feedback from the peer reviewer, then the developer can submit the issue for integration. If there have been significant changes after the peer review, or if the peer reviewer has raised concerns about the approach taken, then the developer should offer the issue up for peer review again, most often to the same peer reviewer, but not necessarily.
 
 Submitting an issue to integration is much the same as for any Moodle code. In some cases the Component Lead may perform a Component Lead Review instead of the integration team. See [[Integration Review]] and the information about the integration workflow above.
 
 ## Fixing a bug
-Bug fixes, and minor features or enhancements should go through the following process. (The only exception is English language string typo fixes or suggested improvements, which may be contributed to the en_fix language pack on the [Moodle translation site](http://lang.moodle.org/).)
+
+Bug fixes, and minor features or enhancements should go through the following process. (The only exception is English language string typo fixes or suggested improvements, which may be contributed to the `en_fix` language pack on the [Moodle translation site](http://lang.moodle.org/).)
+
 ### Make sure there is a tracker issue
+
 Every change must have an issue in the tracker. If you are fixing a bug, there is probably one there already, but if not, create one. [[Tracker tips|Tips for searching tracker]].
+
 ### Decide which branches the fix is required on
+
 Bugs should normally be fixed on all the supported stable branches that are affected. New features should just go into master, but sometimes minor enhancements are made on the most recent stable branch.
+
 ### Develop your change using git
+
 Develop your fix and push the change to an open git repository, for example on github.com. See also [[Git for developers]]
 
 It is essential that your code follows the [[Coding|Moodle Coding Guide]].
 
-You will need to push one commit for each branch the fix needs to be applied to. Often people use branch names like MDL-12345-31_brief_name so it is clear what each branch is. [git cherry-pick](http://kernel.org/pub/software/scm/git/docs/git-cherry-pick.html) can help with replicating the fix onto different branches.
+You will need to push one commit for each branch the fix needs to be applied to. Often people use branch names like `MDL-12345-31_brief_name` so it is clear what each branch is. [git cherry-pick](http://kernel.org/pub/software/scm/git/docs/git-cherry-pick.html) can help with replicating the fix onto different branches.
 
 Consider setting up [[Travis integration]] with your repository so tests will be automatically run for you whenever you push work on your fix.
+
 ### Submit your code for peer review
+
 Once your fix is done, it should be submitted for a peer review.
 
 The following information is necessary for this:
-* Information about your public git repository
-** repository URL
-** branch name(s)
-** diff URL
-* [[Testing instructions guide|Testing instructions]] for how to verify your fix is correct.
-If you have never contributed to Moodle and don't see a button "Request peer review", just comment on the issue with the above information. The component lead or another user with sufficient privileges will then send the issue up for peer review for you.
 
-After your first fix is integrated you will be added to developers group and will be able to send issues for peer review yourself. In this case make sure you are listed as Assignee and click on "Request peer review" button in the tracker.
+- Information about your public git repository
+  - repository URL
+  - branch name(s)
+  - diff URL
+- [[Testing instructions guide|Testing instructions]] for how to verify your fix is correct.
+If you have never contributed to Moodle and don't see a button _Request peer review_, just comment on the issue with the above information. The component lead or another user with sufficient privileges will then send the issue up for peer review for you.
+
+After your first fix is integrated you will be added to developers group and will be able to send issues for peer review yourself. In this case make sure you are listed as Assignee and click on _Request peer review_ button in the tracker.
 
 If you've set up [[Travis integration]], the issue will automatically show the Travis build status for the branch(es) you've submitted for peer review.
+
 ### Peer review
+
 The [[HQ component leads]] should peer-review the change. If there is no component lead for an affected component, any other recognised developer may complete the peer review. The peer reviewer will either give you comments on the code and if it needs more work.
 
 Process and the list of things to check are described in [Peer reviewing](process/peer-review).
+
 ### Submit your code for integration
+
 It will then be reviewed the following week by one of the integration team and either integrated or rejected. Once integrated, the fix will be tested, and then included in the next weekly release. For details see [[Integration Review]].
+
 ## Security issues
+
 Issues identified as [[Security|security issues]] are resolved in a slightly different way, in order to achieve responsible disclosure as described in [[Moodle security procedures]].
-* Security issues should be labelled as "Minor" or "Serious" in order control visibility of the issue.
-** An issue reported with a security level of "Could be a security issue" should be evaluated as soon as possible and either set as "Minor" or "Serious" or the security level should be set to "None".
-* Solutions to security issues should not:
-** be made available in public repositories.
-*** If a developer has shared a solution as Git branches via Github, they should be asked to provide the solutions as [[How_to_create_a_patch|stand-alone patches]] attached to the issue and to [[#How to remove a branch from Github|remove the solution from Github]].
-** contain details about the security problem in the commit message.
-*** Instead use generic terms like, "improve", "better handling of" ..
-* The solution will not be integrated until the week before a [[Process#Stable_maintenance_cycles|minor release]] following the normal [[Release process|Release process]]. In short, the issue will be incorporated into the integration version, rebased, tested and made ready for release as a normal issue would, but not until as late as possible.
-* Details of security issues will be shared with registered admins with the minor release.
-* Details of security issues will not be publicly announced until one week after a minor release to allow admins to update.
-Note that not all the labelled (minor) security issues are always handled following the procedure above. It's possible that, after discussion, it's decided a given issue is not a real Moodle security problem (say external disclosures/potential attacks using Moodle as vector, not as target, discussions revealing some private details...). Those issues will be processed as normal issues, generating the needed user documentation if necessary and will be part of the habitual weekly releases.
-#### How to remove a branch from Github
+
+- Security issues should be labelled as "Minor" or "Serious" in order control visibility of the issue.
+  - An issue reported with a security level of "Could be a security issue" should be evaluated as soon as possible and either set as "Minor" or "Serious" or the security level should be set to "None".
+- Solutions to security issues should not:
+  - be made available in public repositories.
+    - If a developer has shared a solution as Git branches via Github, they should be asked to provide the solutions as [[How_to_create_a_patch|stand-alone patches]] attached to the issue and to [[#How to remove a branch from Github|remove the solution from Github]].
+  - contain details about the security problem in the commit message.
+    - Instead use generic terms like, "improve", "better handling of"
+- The solution will not be integrated until the week before a [[Process#Stable_maintenance_cycles|minor release]] following the normal [[Release process|Release process]]. In short, the issue will be incorporated into the integration version, rebased, tested and made ready for release as a normal issue would, but not until as late as possible.
+- Details of security issues will be shared with registered admins with the minor release.
+- Details of security issues will not be publicly announced until one week after a minor release to allow admins to update.
+Note that not all the labelled (minor) security issues are always handled following the procedure above. It's possible that, after discussion, it's decided a given issue is not a real Moodle security problem (say external disclosures/potential attacks using Moodle as vector, not as target, discussions revealing some private details). Those issues will be processed as normal issues, generating the needed user documentation if necessary and will be part of the habitual weekly releases.
+
+### How to remove a branch from Github
+
 To remove a branch from Github, you can use the following command.
- git push github :remote_branch
-Where _remote_branch_ is the name of your remote branch, for example 'wip-mdl-1234'. This effectively replaces the remote branch with nothing, removing the remote branch, but leaving the branch intact in your local Git repository. Please note that its likely that your commit will still exist on github due to the nature of git, so its best to avoid doing this in the first place.
+
+```
+git push github :remote_branch
+```
+
+Where `remote_branch` is the name of your remote branch, for example `wip-mdl-1234`.
+This effectively replaces the remote branch with nothing, removing the remote branch, but leaving the branch intact in your local Git repository. Please note that its likely that your commit will still exist on github due to the nature of git, so its best to avoid doing this in the first place.
+
 ## Policy issues
+
 Occasionally within Moodle we run into policy issues where a high-level decision needs to be made about how things are to be done.
 
 In these cases the process is as follows:
-* Create an issue in the tracker with a [Policy component](https://tracker.moodle.org/browse/MDL/component/12733) and put "POLICY:" as a prefix on the summary.
-* In the description describe the problem clearly as well as all the options. If it's long then make a page here in Moodle Dev Docs and link to it.
-* Do not use this issue for code. If there are issues that depend on this policy decision, then add tracker links to them as dependencies.
-* Feel free to encourage people to come and talk about the policy to support various points of view. The more evidence we have (from everyone in the community) the better.
+
+- Create an issue in the tracker with a [Policy component](https://tracker.moodle.org/browse/MDL/component/12733) and put `POLICY:` as a prefix on the summary.
+- In the description describe the problem clearly as well as all the options. If it's long then make a page here in Moodle Dev Docs and link to it.
+- Do not use this issue for code. If there are issues that depend on this policy decision, then add tracker links to them as dependencies.
+- Feel free to encourage people to come and talk about the policy to support various points of view. The more evidence we have (from everyone in the community) the better.
 Some time has been scheduled in the weekly Moodle HQ meeting to look at Policy issues and try to make decisions on them. We discuss all the evidence and try to achieve a high amount of consensus. Deadlocked issues can be resolved by a decision from Martin Dougiamas (this is rarely needed).
 
 Decisions will be posted on the issue and that issue will be closed, allowing any dependent issues to continue to integration (or not). Decisions are final and bribes hardly ever work.
+
 ## See also
-* [[Release process]]
-* [[Deprecation]]
-* [Integration dashboard](http://tracker.moodle.org/secure/Dashboard.jspa?selectPageId=11350)
+
+- [[Release process]]
+- [[Deprecation]]
+- [Integration dashboard](http://tracker.moodle.org/secure/Dashboard.jspa?selectPageId=11350)
 Walks-though of the process for contributors:
-* By Dan Poltawski, Integrator: http://www.slideshare.net/poltawski/how-to-guarantee-your-change-is-integrated-to-moodle-core, https://www.youtube.com/watch?v=836WtnM2YpM
-* By Tim Hunt, contributor: http://tjhunt.blogspot.co.uk/2012/03/fixing-bug-in-moodle-core-mechanics.html and https://www.youtube.com/watch?v=gPPA3h7OGQU and https://youtu.be/Hu8ne0NCRAg?t=11659
+- By Dan Poltawski, Integrator: http://www.slideshare.net/poltawski/how-to-guarantee-your-change-is-integrated-to-moodle-core, https://www.youtube.com/watch?v=836WtnM2YpM
+- By Tim Hunt, contributor: http://tjhunt.blogspot.co.uk/2012/03/fixing-bug-in-moodle-core-mechanics.html and https://www.youtube.com/watch?v=gPPA3h7OGQU and https://youtu.be/Hu8ne0NCRAg?t=11659

--- a/general/development/process/peer-review.md
+++ b/general/development/process/peer-review.md
@@ -81,7 +81,6 @@ Ensure that any new User Interface feature in Moodle 4.0 or later which matches 
 - Has appropriate descriptions
 - Respects all Moodle-supplied themes
 
-
 ### Language
 
 To achieve appropriate internationalisation of Moodle, language strings must be managed correctly.
@@ -122,6 +121,7 @@ Ensure that:
 - **Behat tests pass** for related areas where changes have been made, especially when it involved UI changes.
 
 ### Security
+
 The user community relies on Moodle being responsibly secure.
 
 Ensure that:
@@ -135,6 +135,7 @@ Ensure that:
   - The issue will not be integrated until just before the next minor version release.
 
 ### Privacy
+
 The user community relies on Moodle keeping user's privacy.
 
 Ensure that:
@@ -166,8 +167,8 @@ Ensure that:
   - What they did to mitigate performance impact, or why they thought it wasn't an issue.
   - Why they made certain trade-offs.
 
-
 ### Documentation
+
 Work does not stop when code is integrated.
 
 Ensure that:
@@ -185,6 +186,7 @@ Ensure that:
 - Also, verify that the components for the issue are correctly set, so maintainers (subscribed by default) will be mailed about issues early in the process.
 
 ### Git
+
 Ensure that:
 
 - The commit matches the [Coding style](/general/development/policies/codingstyle)
@@ -192,6 +194,7 @@ Ensure that:
 - The original author of the work provided as a patch has been given credit within the commit (as author of in the commit message if changes were made).
 
 ### Third party code
+
 Does the change contain [third party code](https://docs.moodle.org/dev/Plugin_with_third_party_libraries)? If so, ensure that:
 
 - The code is licensed under a [GPL compatible license](http://www.gnu.org/licenses/license-list.html#GPLCompatibleLicenses%7C).
@@ -201,8 +204,8 @@ Does the change contain [third party code](https://docs.moodle.org/dev/Plugin_wi
 - Does not duplicate the functionality of any existing api or third party library in core.
 - Any modifications to third party code are recorded in readme_moodle.txt
 
-
 ### Sanity check
+
 Ensure that:
 
 - The code seems to solve the described problem completely within its reported scope (and further issues have been created to resolve remaining parts or further refactoring);
@@ -213,6 +216,7 @@ Ensure that:
 - There are comments on tracker explaining why current approach was taken and why other options (especially large issues). If not comment asking them to explain
 
 ### Icons
+
 Are new icons being introduced? If so, ensure that:
 
 - The icons abide by our icon guidelines with regards to size, design and format
@@ -220,6 +224,7 @@ Are new icons being introduced? If so, ensure that:
 - The icons are in a pix folder that makes sense
 
 ### The Moodle mobile app
+
 The Moodle app supports most of the student-related Moodle functionality. It is important to think about how a change in that type of functionality might affect it.
 
 Ensure that:
@@ -231,6 +236,7 @@ Ensure that:
 - The testing instructions include testing steps for the Moodle App
 
 ### Accessibility
+
 We aim for Moodle to be accessible to everyone, especially to people with disabilities. When peer-reviewing a patch that introduces changes on the frontend, it would be good to do a quick accessibility check on the page or on the UI elements affected by the patch.
 
 Some quick checks that can be done to check for accessibility:
@@ -257,7 +263,6 @@ During peer reviews, please mark this category with either of the following (whi
 - **N** - When accessibility has been checked but accessibility issues were found.
 - **N/A** - When an accessibility check is not applicable for the patch.
 - **S** - To indicate that an accessibility check might be needed but has been skipped by the peer reviewer.
-
 
 ## Process
 
@@ -295,7 +300,6 @@ Please indicate If you are willing to continue working on this issue and complet
 
 Can you help with peer reviewing? If so, please see the [list of issues waiting for peer review](https://tracker.moodle.org/issues/?filter=13607).
 
-
 ### Peer review for development by HQ or a known common contributor
 
 When code comes from a HQ developer or external developer who has been contributing significantly to Moodle and is well acquainted with Moodle standards, peer review is limited to checking the code according to the Checklist below.
@@ -317,7 +321,6 @@ There could be situations when the patch is incomplete, does not fix the origina
 If the issue has passed peer review but the integrator or tester has raised some questions about it, then normally the developer who created the patch would be expected to respond. If they do no respond quickly enough, then the peer reviewer is expected to step in and take responsibility for the change they reviewed.
 
 Once the issue is ready for integration, you can submit it to integration on behalf of the developer. Most external developers (those who are not in the jira-developers group) do not have permission to submit their own issues to integration so cannot do it themselves.
-
 
 #### Replies templates
 
@@ -348,4 +351,5 @@ Please let me know If you are willing to continue working on this issue and comp
 ```
 
 ## See also
+
 - [Code checker plugin](http://moodle.org/plugins/view.php?plugin=local_codechecker)

--- a/general/development/tracker.md
+++ b/general/development/tracker.md
@@ -31,7 +31,6 @@ Before creating a new issue, please try searching to check whether it has been r
 
 See also [Tracker tips](./tracker/tips).
 
-
 ## Reporting an issue
 
 *First check whether the issue has already been reported by searching (see above).*
@@ -65,8 +64,8 @@ If you report an issue, you will automatically receive email notification of upd
 
 :::
 
-
 ## Helping determine development priorities
+
 You can help determine Moodle development priorities by voting for issues that you'd most like to see fixed.
 
 - Click the 'Vote' link on the right of the issue page.
@@ -97,7 +96,6 @@ If you find that a bug is still affecting a stable version of Moodle, despite th
 
 1. Create a new issue for the bug
 2. Go back to the closed issue, then in the More menu select 'Link'. Enter the number of the issue you've just created and a comment. This will generate an email notification to all watchers, so they know to watch, vote or comment on the new issue from then on.
-
 
 ## See also
 

--- a/general/development/tracker/tips/index.md
+++ b/general/development/tracker/tips/index.md
@@ -47,7 +47,6 @@ Now you can enter queries in the Jira Query Language (JQL). Use as many AND, OR 
 | `issue in linkedIssues("MDL-12345","duplicated by")` | Returns all the issues directly and indirectly duplicated by 'MDL-12345'. i.e. if there is 'MDL-12222'  duplicated by 'MDL-12345'   and 'MDL-11111'  duplicated by 'MDL-12222', both 'MDL-11111' and 'MDL-12222' will be returned as search results. |
 | [`issue in favouriteIssues()`](https://tracker.moodle.org/issues/?jql=issue%20in%20favouriteIssues%28%29) | issues that you marked as favourite |
 
-
 More documentation on [https://confluence.atlassian.com/jirasoftwareserver071/advanced-searching-800707146.html Advanced searching]
 
 ## Using filters
@@ -68,6 +67,7 @@ Now you will be notified daily about new issues in Assignment component. You can
 Watchers automatically receive notifications about the updates of the issues they are watching. Using filter subscription you can either monitor issues that you are not watching or monitor issues that are in particular state and were not updated.
 
 ### Useful queries
+
 - [Issues reported by me not against current versions](https://tracker.moodle.org/issues/?jql=project%20%3D%20mdl%20and%20resolution%20%3D%20unresolved%20and%20type%20in%20%28bug%29%20and%20%22Affected%20Branches%22%20!~%20MOODLE_310_STABLE%20and%20%22Affected%20Branches%22%20!~%20MOODLE_311_STABLE%20and%20reporter%20%3D%20currentUser%28%29) - make sure that you keep track of your own issues!
 - [Untriaged issues in my components](https://tracker.moodle.org/issues/?jql=component%20in%20%28componentsLeadByUser%28%29%29%20AND%20resolution%20%3D%20Unresolved%20AND%20updatedDate%20%3E%20-14d%20AND%20project%20%3D%20MDL%20AND%20%28%20labels%20is%20EMPTY%20OR%20labels%20not%20in%20%28triaged%2C%20triaging_in_progress%29%29%20ORDER%20BY%20updatedDate%20ASC) (works only for component leads)
 - [Waiting for peer review for 21 days](https://tracker.moodle.org/issues/?jql=status%20changed%20to%20%22Waiting%20for%20peer%20review%22%20before%20startofday(-21)%20and%20status%20%3D%20%22Waiting%20for%20peer%20review%22)

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
-    "test": "jest"
+    "test": "jest",
+    "lint": "markdownlint 'docs/**/*.md' 'general/**/*.md' '*.md'"
   },
   "dependencies": {
     "@cmfcmf/docusaurus-search-local": "^0.10.0",
@@ -48,6 +49,7 @@
   "devDependencies": {
     "babel-jest": "^27.5.1",
     "jest": "^27.5.1",
+    "markdownlint-cli": "^0.31.1",
     "ts-jest": "^27.1.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3721,6 +3721,11 @@ commander@^8.3.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
   integrity sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==
 
+commander@~9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-9.0.0.tgz#86d58f24ee98126568936bd1d3574e0308a99a40"
+  integrity sha512-JJfP2saEKbQqvW+FI93OYUB4ByV5cizMpFMiiJI8xDbBvQvSkIk0VvQdn1CZ8mqAO8Loq2h0gYTYtDFUZUeERw==
+
 common-tags@^1.8.0:
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.8.2.tgz#94ebb3c076d26032745fd54face7f688ef5ac9c6"
@@ -4982,6 +4987,11 @@ entities@^3.0.1:
   resolved "https://registry.yarnpkg.com/entities/-/entities-3.0.1.tgz#2b887ca62585e96db3903482d336c1006c3001d4"
   integrity sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==
 
+entities@~2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-2.1.0.tgz#992d3129cf7df6870b96c57858c249a120f8b8b5"
+  integrity sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==
+
 error-ex@^1.3.1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
@@ -5504,6 +5514,11 @@ get-package-type@^0.1.0:
   resolved "https://registry.yarnpkg.com/get-package-type/-/get-package-type-0.1.0.tgz#8de2d803cff44df3bc6c456e6668b36c3926e11a"
   integrity sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==
 
+get-stdin@~9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-9.0.0.tgz#3983ff82e03d56f1b2ea0d3e60325f39d703a575"
+  integrity sha512-dVKBjfWisLAicarI2Sf+JuBE/DghV4UzNAVe9yhEJuzeREd3JhOTE9cUaJTeSa77fsbQUK3pcOpJfM59+VKZaA==
+
 get-stream@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-4.1.0.tgz#c1b255575f3dc21d59bfc79cd3d2b46b1c3a54b5"
@@ -5555,7 +5570,7 @@ glob-to-regexp@^0.4.1:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
   integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
-glob@^7.0.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
+glob@^7.0.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@~7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
   integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
@@ -6012,7 +6027,7 @@ idb@^6.1.4:
   resolved "https://registry.yarnpkg.com/idb/-/idb-6.1.5.tgz#dbc53e7adf1ac7c59f9b2bf56e00b4ea4fce8c7b"
   integrity sha512-IJtugpKkiVXQn5Y+LteyBCNk1N8xpGV3wWZk9EVtZWH8DYkjBn0bX1XnGP9RkyZF0sAcywa6unHqSWKe7q4LGw==
 
-ignore@^5.1.9, ignore@^5.2.0:
+ignore@^5.1.9, ignore@^5.2.0, ignore@~5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
   integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
@@ -6083,7 +6098,7 @@ inherits@2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
-ini@2.0.0:
+ini@2.0.0, ini@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ini/-/ini-2.0.0.tgz#e5fd556ecdd5726be978fa1001862eacb0a94bc5"
   integrity sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==
@@ -7010,6 +7025,11 @@ json5@2.x, json5@^2.1.2, json5@^2.2.0:
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"
   integrity sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==
 
+jsonc-parser@~3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.0.0.tgz#abdd785701c7e7eaca8a9ec8cf070ca51a745a22"
+  integrity sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==
+
 jsonfile@^6.0.1:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
@@ -7080,6 +7100,13 @@ lines-and-columns@^1.1.6:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
+
+linkify-it@^3.0.1:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-3.0.3.tgz#a98baf44ce45a550efb4d49c769d07524cc2fa2e"
+  integrity sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==
+  dependencies:
+    uc.micro "^1.0.1"
 
 loader-runner@^4.2.0:
   version "4.2.0"
@@ -7289,6 +7316,45 @@ markdown-escapes@^1.0.0:
   resolved "https://registry.yarnpkg.com/markdown-escapes/-/markdown-escapes-1.0.4.tgz#c95415ef451499d7602b91095f3c8e8975f78535"
   integrity sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==
 
+markdown-it@12.3.2:
+  version "12.3.2"
+  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-12.3.2.tgz#bf92ac92283fe983fe4de8ff8abfb5ad72cd0c90"
+  integrity sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==
+  dependencies:
+    argparse "^2.0.1"
+    entities "~2.1.0"
+    linkify-it "^3.0.1"
+    mdurl "^1.0.1"
+    uc.micro "^1.0.5"
+
+markdownlint-cli@^0.31.1:
+  version "0.31.1"
+  resolved "https://registry.yarnpkg.com/markdownlint-cli/-/markdownlint-cli-0.31.1.tgz#8db34eec453e84bed06a954c8a289333f7c2c1c7"
+  integrity sha512-keIOMwQn+Ch7MoBwA+TdkyVMuxAeZFEGmIIlvwgV0Z1TGS5MxPnRr29XCLhkNzCHU+uNKGjU+VEjLX+Z9kli6g==
+  dependencies:
+    commander "~9.0.0"
+    get-stdin "~9.0.0"
+    glob "~7.2.0"
+    ignore "~5.2.0"
+    js-yaml "^4.1.0"
+    jsonc-parser "~3.0.0"
+    markdownlint "~0.25.1"
+    markdownlint-rule-helpers "~0.16.0"
+    minimatch "~3.0.5"
+    run-con "~1.2.10"
+
+markdownlint-rule-helpers@~0.16.0:
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/markdownlint-rule-helpers/-/markdownlint-rule-helpers-0.16.0.tgz#c327f72782bd2b9475127a240508231f0413a25e"
+  integrity sha512-oEacRUVeTJ5D5hW1UYd2qExYI0oELdYK72k1TKGvIeYJIbqQWAz476NAc7LNixSySUhcNl++d02DvX0ccDk9/w==
+
+markdownlint@~0.25.1:
+  version "0.25.1"
+  resolved "https://registry.yarnpkg.com/markdownlint/-/markdownlint-0.25.1.tgz#df04536607ebeeda5ccd5e4f38138823ed623788"
+  integrity sha512-AG7UkLzNa1fxiOv5B+owPsPhtM4D6DoODhsJgiaNg1xowXovrYgOnLqAgOOFQpWOlHFVQUzjMY5ypNNTeov92g==
+  dependencies:
+    markdown-it "12.3.2"
+
 mdast-squeeze-paragraphs@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/mdast-squeeze-paragraphs/-/mdast-squeeze-paragraphs-4.0.0.tgz#7c4c114679c3bee27ef10b58e2e015be79f1ef97"
@@ -7327,7 +7393,7 @@ mdn-data@2.0.14:
   resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.14.tgz#7113fc4281917d63ce29b43446f701e68c25ba50"
   integrity sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==
 
-mdurl@^1.0.0:
+mdurl@^1.0.0, mdurl@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
   integrity sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=
@@ -7467,6 +7533,13 @@ minimatch@^3.0.4:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+  dependencies:
+    brace-expansion "^1.1.7"
+
+minimatch@~3.0.5:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.8.tgz#5e6a59bd11e2ab0de1cfb843eb2d82e546c321c1"
+  integrity sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==
   dependencies:
     brace-expansion "^1.1.7"
 
@@ -8934,6 +9007,16 @@ rtlcss@^3.5.0:
     postcss "^8.3.11"
     strip-json-comments "^3.1.1"
 
+run-con@~1.2.10:
+  version "1.2.10"
+  resolved "https://registry.yarnpkg.com/run-con/-/run-con-1.2.10.tgz#90de9d43d20274d00478f4c000495bd72f417d22"
+  integrity sha512-n7PZpYmMM26ZO21dd8y3Yw1TRtGABjRtgPSgFS/nhzfvbJMXFtJhJVyEgayMiP+w/23craJjsnfDvx4W4ue/HQ==
+  dependencies:
+    deep-extend "^0.6.0"
+    ini "~2.0.0"
+    minimist "^1.2.5"
+    strip-json-comments "~3.1.1"
+
 run-parallel@^1.1.9:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
@@ -9477,7 +9560,7 @@ strip-final-newline@^2.0.0:
   resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
   integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
 
-strip-json-comments@^3.1.1:
+strip-json-comments@^3.1.1, strip-json-comments@~3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
@@ -9802,6 +9885,11 @@ ua-parser-js@^0.7.30:
   version "0.7.31"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.31.tgz#649a656b191dffab4f21d5e053e27ca17cbff5c6"
   integrity sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ==
+
+uc.micro@^1.0.1, uc.micro@^1.0.5:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.6.tgz#9c411a802a409a91fc6cf74081baba34b24499ac"
+  integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
 
 unbox-primitive@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
These commits add:
- linting using `markdownlint-cli`
- improvements to README.md to document this change and how to run it
- fixes for existing linting issues

We can refine these rules over time, but I feel that it's better to start strict and become less so, than to start our journey without many rules and then need to add them and update an increasing amount of documentation in the process. These rules really aren't too contentious anyway.