### PR TITLE
Update coding style to more clearly indicate examples

### DIFF
--- a/general/development/policies/codingstyle/index.md
+++ b/general/development/policies/codingstyle/index.md
@@ -7,30 +7,31 @@ tags:
   - Developer processes
 ---
 
-import { CodeBlock, TabItem, Tabs } from '@site/src/components';
+import { CodeBlock, TabItem, Tabs, ValidExample, InvalidExample } from '@site/src/components';
 
 ## Overview
+
 ### Scope
 
 This document describes **style** guidelines for developers working on or with Moodle code. It talks purely about the mechanics of code layout and the choices we have made for Moodle. The intent of this specification is to reduce cognitive friction when scanning code from different authors. It does so by enumerating a shared set of rules and expectations about how to format PHP code.
 
 Unless otherwise specified, this Coding Style document **will defer to [PSR-12](https://www.php-fig.org/psr/psr-12/), and [PSR-1](https://www.php-fig.org/psr/psr-1/)** in that order.
 
-Where a **de-facto Moodle standard*** is encountered but is undocumented, an appropriate **MDLSITE** issue should be raised to have the standard either documented within this Coding style guide, or rejected and the PSR recommendations adopted instead.
+Where a **de-facto Moodle standard** is encountered but is undocumented, an appropriate **MDLSITE** issue should be raised to have the standard either documented within this Coding style guide, or rejected and the PSR recommendations adopted instead.
 
 :::info
-*"de-facto Moodle standard"* is any coding style which is commonly and typically used in Moodle
+A "de-facto Moodle standard"* is any coding style which is commonly and typically used in Moodle.
 :::
 
 ### Goals
 
-Consistent coding style is important in any development project, and particularly when many developers are involved.  A standard style helps to ensure that the code is easier to read and understand, which helps overall quality.
+Consistent coding style is important in any development project, and particularly when many developers are involved. A standard style helps to ensure that the code is easier to read and understand, which helps overall quality.
 
 Abstract goals we strive for:
 
 - simplicity
 - readability
-- tool friendliness, such as use of method signatures, constants, and patterns that support IDE tools and auto-completion of method, class, and constant names.
+- tool friendliness, such as use of method signatures, constants, and patterns that support IDE tools and autocompletion of method, class, and constant names.
 
 When considering the goals above, each situation requires an examination of the circumstances and balancing of various trade-offs.
 
@@ -42,10 +43,10 @@ For details about using the Moodle API to get things done, see the [[Coding|codi
 
 ### Useful tools
 
-There are a couple of different tools available to help you in writing code that conforms to this guide.
+Several tools are available to help you in write code that conforms to this guide:
 
-; Code checker (integrates with [eclipse/phpstorm](https://github.com/moodlehq/moodle-local_codechecker/blob/master/README.md#ide-integration)): https://moodle.org/plugins/view.php?plugin=local_codechecker
-; Moodle PHPdoc checker: https://moodle.org/plugins/local_moodlecheck
+- The Moodle [Code checker](https://moodle.org/plugins/view.php?plugin=local_codechecker) (integrates with [eclipse/phpstorm](https://github.com/moodlehq/moodle-local_codechecker/blob/master/README.md#ide-integration))
+- The Moodle [PHPdoc checker](https://moodle.org/plugins/local_moodlecheck)
 
 It is worth using both tools to check the code you are writing as they both perform slightly different checks.
 If you can get your code to pass both then you are well on the way to making friends with those who will be reviewing your work.
@@ -54,17 +55,23 @@ If you can get your code to pass both then you are well on the way to making fri
 
 ### PHP tags
 
-Always use "long" php tags.  However, to avoid whitespace problems, DO NOT include the closing tag at the very end of the file.
+Always use "long" php tags. However, to avoid whitespace problems, DO NOT include the closing tag at the very end of the file.
 
 import Example_PhpTags_Good from '!!raw-loader!./_examples/phptags_good.php';
 
+<ValidExample>
+
 <CodeBlock language="php" title="Using long tags in a PHP file">{Example_PhpTags_Good}</CodeBlock>
+
+</ValidExample>
 
 ### Indentation
 
 Use an indent of **4 spaces** with no tab characters. Editors should be configured to treat tabs as spaces in order to prevent injection of new tab characters into the source code.
 
 **Do not** indent the main script level:
+
+<ValidExample>
 
 ```php title="An example of correct indentation at the main script level"
 <?php
@@ -77,6 +84,10 @@ if ($a > 10) {
 }
 ```
 
+</ValidExample>
+
+<InvalidExample>
+
 ```php title="An example of incorrect indentation at the main script level"
 <?php
     require('config.php');
@@ -88,13 +99,15 @@ if ($a > 10) {
     }
 ```
 
+</InvalidExample>
+
 SQL queries use special indentation, see [[SQL coding style]].
 
 ### Maximum Line Length
 
 The key issue is readability.
 
-Aim for 132 characters if it is convenient,  it is not recommended to use more than 180 characters.
+Aim for 132 characters if it is convenient, it is not recommended to use more than 180 characters.
 
 The exception are string files in the <tt>/lang</tt> directory where lines <tt>$string['id'] = 'value';</tt> should have the value defined as a single string of any length, wrapped by quotes (no concatenation operators, no heredoc and no newdoc syntax). This helps to parse and process these string files without including them as a PHP code.
 
@@ -108,6 +121,9 @@ Whenever wrapping lines, following rules should generally apply:
 See examples in the following sections.
 
 #### Wrapping control structures
+
+<ValidExample>
+
 ```php
 while ($fileinfolevel && $params['component'] === 'user'
         && $params['filearea'] === 'private') {
@@ -116,8 +132,14 @@ while ($fileinfolevel && $params['component'] === 'user'
 }
 ```
 
+</ValidExample>
+
 #### Wrapping if-statement conditions
+
 There is nothing special and the control structures rule would still apply.
+
+<ValidExample>
+
 ```php
 if (($userenrol->timestart && $userenrol->timestart < $limit) ||
         (!$userenrol->timestart && $userenrol->timecreated < $limit)) {
@@ -125,7 +147,11 @@ if (($userenrol->timestart && $userenrol->timestart < $limit) ||
 }
 ```
 
+</ValidExample>
+
 However, if you have a few conditions in one control structure, try setting some helper variables for evaluating the conditions to improve the readability.
+
+<ValidExample>
 
 ```php
 $iscourseorcategoryitem = ($element['object']->is_course_item() || $element['object']->is_category_item());
@@ -136,7 +162,12 @@ if ($iscourseorcategoryitem && $usesscaleorvalue) {
 }
 ```
 
+</ValidExample>
+
 Compare it with the following.
+
+<InvalidExample>
+
 ```php
 // DO NOT DO THIS.
 if (($element['object']->is_course_item() || $element['object']->is_category_item())
@@ -146,7 +177,12 @@ if (($element['object']->is_course_item() || $element['object']->is_category_ite
 }
 ```
 
+</InvalidExample>
+
 #### Wrapping class declarations
+
+<ValidExample>
+
 ```php
 class foo implements bar, baz, qux, quux, quuz, corge, grault,
         garply, waldo, fred, plugh, xyzzy, thud {
@@ -155,7 +191,11 @@ class foo implements bar, baz, qux, quux, quuz, corge, grault,
 }
 ```
 
+</ValidExample>
+
 Alternatively you may want to provide each implemented interface on its own line if it helps readability:
+
+<ValidExample>
 
 ```php
 class provider implements
@@ -168,8 +208,13 @@ class provider implements
 }
 ```
 
+</ValidExample>
+
 #### Wrapping of the function signatures
-```php
+
+<ValidExample>
+
+```php title="Wrapping function signatures with 8 spaces"
 /**
  * ...
  */
@@ -183,22 +228,76 @@ protected function component_class_callback_failed(\Throwable $e, string $compon
 }
 ```
 
+</ValidExample>
+
+<ValidExample>
+
+```php title="Wrapping function signatures following PSR-12"
+/**
+ * ...
+ */
+protected function component_class_callback_failed(
+    \Throwable $e,
+    string $component,
+    string $interface,
+    string $methodname,
+    array $params
+) {
+    global $CFG, $DB;
+
+    if ($this->observer) {
+        // ...
+    }
+}
+```
+
+</ValidExample>
+
 #### Wrapping parameters of a function call
+
 Normally, parameters will just fit on one line. If they eventually become too long to fit a single line or of it helps readability, indent with 4 spaces.
 
-```php
+<ValidExample>
+
+```php title="Wrapping function calls the Moodle way"
 do_something($param1, $param2, null, null,
     $param5, null, true);
 ```
 
+</ValidExample>
+
+<ValidExample>
+
+```php title="Wrapping function calls following PSR-12"
+do_something(
+    $param1,
+    $param2,
+    null,
+    null,
+    $param5,
+    null,
+    true
+);
+```
+
+</ValidExample>
+
 #### Wrapping arrays
+
 There is nothing special and the general rules apply again. Indent the wrapped line with 4 spaces.
+
+<ValidExample>
+
 ```php
 $plugininfo['preferences'][$plugin] = ['id' => $plugin, 'link' => $pref_url,
     'string' => $modulenamestr];
 ```
 
+</ValidExample>
+
 In many cases, the following style with each item on its own line will make the code more readable.
+
+<ValidExample>
 
 ```php
 $plugininfo['preferences'][$plugin] = [
@@ -207,18 +306,30 @@ $plugininfo['preferences'][$plugin] = [
     'string' => $modulenamestr,
 ];
 ```
+
+</ValidExample>
+
 :::note
-The last item has a trailing comma left there which allows to extend the list of items later with a cleaner diff. For the same reason, it is better not to align the assignment operators.
+
+The last item has a trailing comma left there which allows to extend the list of items later with a cleaner diff.
+For the same reason, it is better not to align the assignment operators.
+
 :::
 
 #### Wrapping arrays passed as function parameter
+
 This is just an example of combining some of the examples above.
+
+<ValidExample>
+
 ```php
 $url = new moodle_url('/course/loginas.php', [
     'id' => $course->id,
     'sesskey' => sesskey(),
 ]);
 ```
+
+</ValidExample>
 
 ### Line Termination
 
@@ -228,7 +339,9 @@ $url = new moodle_url('/course/loginas.php', [
 - There must be no extra blank lines at the end of a file; every file should end with a single LF character.
 
 :::note
+
 This is consistent with the conventions of [PSR-12](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-12-extended-coding-style-guide.md#22-files).
+
 :::
 
 ## Naming Conventions
@@ -236,14 +349,17 @@ This is consistent with the conventions of [PSR-12](https://github.com/php-fig/f
 ### Filenames
 
 Filenames should:
+
 - be whole english words
 - be as short as possible
 - use lowercase letters only
-- end in .php, .html, .js, .css or .xml
+- end in `.php`, `.html`, `.js`, `.css` or `.xml`
 
 ### Classes
 
 Class names should always be lower-case English words, separated by underscores:
+
+<ValidExample>
 
 ```php
 class some_custom_class {
@@ -253,13 +369,21 @@ class some_custom_class {
 }
 ```
 
-Always use () when creating new instances even if constructor does not need any parameters.
+</ValidExample>
 
-```php
+Always use `()` when creating new instances even if constructor does not need any parameters.
+
+<ValidExample>
+
+```php title="Example of class instantiation"
 $instance = new some_custom_class();
 ```
 
-When you want a plain object of no particular class, for example when you are preparing some data to insert into the database with $DB->insert_record, you should use the PHP standard class **stdClass**. For example:
+</ValidExample>
+
+When you want a plain object of no particular class, for example when you are preparing some data to insert into the database with $DB->insert_record, you should use the PHP standard class `stdClass`. For example:
+
+<ValidExample>
 
 ```php
 $row = new stdClass();
@@ -268,8 +392,27 @@ $row->field = 'something';
 $DB->insert_record('table', $row);
 ```
 
+</ValidExample>
+
+Alternatively you can cast an array to an object:
+
+<ValidExample>
+
+```php title="Creating a stdClass from an object"
+$row = (object) [
+    'id' => $id,
+    'field' => 'something',
+];
+$DB->insert_record('table', $row);
+```
+
+</ValidExample>
+
 :::info
-Before Moodle 2.0, we used to define a class **object** extending stdClass, and use new object(); This has now been deprecated. Please use stdClass instead.*
+
+Before Moodle 2.0, Moodle defined a class named `object` extending `stdClass`, and recommended instantiation using `new object();`.
+This has now been deprecated. Please use `stdClass` or the array instantiation instead instead.
+
 :::
 
 ### Functions and Methods
@@ -281,17 +424,24 @@ Verbosity is encouraged: function names should be as illustrative as is practica
 The uses of type hints and return type declarations is required in PHP in all possible locations for all new code. There will be necessary exclusions, such as code extending existing non-compliant code and implementing things where it is not available. Progressive approach will be applied.
 
 :::note
+
 There is no space between the function name and the following (brackets). There is also no whitespace between the nullable character (question mark - ?) and params or return types or between the function closing brackets and the colon.
+
 :::
+
+<ValidExample>
 
 ```php
 function report_participation_get_overviews(string $action, ?int userid): ?array {
-
     // Actual function code goes here.
 }
 ```
 
+</ValidExample>
+
 There is an exception for [[Activity modules|activity modules]] that still use only plugin name as the prefix for legacy reasons.
+
+<ValidExample>
 
 ```php
 function forum_set_display_mode($mode = 0) {
@@ -301,42 +451,81 @@ function forum_set_display_mode($mode = 0) {
 }
 ```
 
+</ValidExample>
+
 #### Function Parameters
 
 Parameters are always simple lowercase English words (sometimes more than one, like $initialvalue), and should always have sensible defaults if possible.
 
-Use "null" as the default value instead of "false" for situations like this where a default value isn't needed.
+Use `null` as the default value instead of `false` for situations like this where a default value isn't needed.
+
+<ValidExample>
+
 ```php
-public function foo($required, $optional = null)
+public function foo($required, $optional = null);
 ```
 
+</ValidExample>
+
 However, if an optional parameter is boolean, and its logical default value should be true, or false, then using true or false is acceptable.
+
+:::note Type hinting with optional parameters
+
+When type-hinting optional parameters, technically the nullable hint is optional, but it is highly recommended as it leads to consistent code.
+
+```php
+/**
+ * Get the name, using a default if not available.
+ *
+ * @param null|string $default The value to get if not found
+ */
+public function get(?string $default = null): string;
+```
+
+:::
 
 ### Variables
 
 Variable names should always be easy-to-read, meaningful lower-case English words. If you really need more than one word then run them together, but keep them as short as possible. Use **plural** names for arrays of objects. Use **positive** variables names always (allow, enable not prevent, disable).
 
- GOOD: $quiz
- GOOD: $errorstring
- GOOD: $assignments (for an array of objects)
- GOOD: $i (but only in little loops)
- GOOD: $allowfilelocking = false
+<ValidExample>
 
- BAD: $Quiz
- BAD: $camelCase
- BAD: $aReallyLongVariableNameWithoutAGoodReason
- BAD: $error_string
- BAD: $preventfilelocking = true
+```php
+$quiz = null;
+$errorstring = null;
+$assignments = null; // For an array of objects.
+$i = null; // Only in little loops.
+$allowfilelocking = false;
+```
 
-Core global variables in Moodle are identified using uppercase variables (ie $CFG, $SESSION, $USER, $COURSE, $SITE, $PAGE, $DB and $THEME).  Don't create any more!
+</ValidExample>
+
+<InvalidExample>
+
+```php
+$Quiz = null; // Variables should be all lower case.
+$camelCase = null; // Variables should not be in camelCase, PascalCake.
+$aReallyLongVariableNameWithoutAGoodReason = null; // Variable names should be sensible and short.
+$error_string = null; // Variable names should not contain underscores.
+$preventfilelocking = true; // Variable names should not be negative.
+ ```
+
+</InvalidExample>
+
+Core global variables in Moodle are identified using uppercase variables (that is `$CFG`, `$SESSION`, `$USER`, `$COURSE`, `$SITE`, `$PAGE`, `$DB`, and `$THEME`). Don't create any more!
 
 ### Constants
 
 Constants should always be in upper case, and always start with [[Frankenstyle]] prefix and plugin name (in case of activities the module name only for legacy reasons). They should have words separated by underscores.
+
+<ValidExample>
+
 ```php
 define('BLOCK_COURSE_OVERVIEW_SHOWCATEGORIES_NONE', '0');
 define('FORUM_MODE_FLATOLDEST', 1);
 ```
+
+</ValidExample>
 
 ### Booleans and the null value
 
@@ -345,27 +534,37 @@ Use lower case for **true**, **false** and **null**.
 ### Namespaces
 
 Formal namespaces are required for any new classes in Moodle. The following exceptions apply:
+
 1. There is no requirement to move existing non-namespaced classes to a namespace; and
 1. Where an existing mechanism exists for loading a class, and that mechanism does not support the use of a namespaced class, the existing [[Frankenstyle]] prefix on the class name will be allowed.
 
 The use of a [[Frankenstyle#Class names|Frankenstyle prefix on class names]] is deprecated and should only be used in the above exceptions.
 
-GOOD:
-```php
+<ValidExample>
+
+```php title="Correct use of namespaces"
+// A namespace for the `mod_forum` plugin.
+
 namespace mod_forum;
 class example {
 }
 
+// A namespace for the `external` subsystem usage in the `mod_forum` plugin.
 namespace mod_forum\external;
 class example {
 }
 
+// A namespace for the `core_user` core subsystem.
 namespace core_user;
 class example {}
 ```
 
-BAD (deprecated):
-```php
+</ValidExample>
+
+<InvalidExample>
+
+```php title="Incorrect use of namespaces"
+// Namespaced classes are no longer allowed for new code, except where it is unavoidable.
 class mod_forum_example {
 }
 
@@ -376,26 +575,37 @@ class core_user_example {
 }
 ```
 
+</InvalidExample>
+
 The use of namespaces must conform to the following rules:
-1. Classes belonging to a namespace must be created in a classes directory inside a plugin (e.g. mod/forum/classes), or for core code, in lib/classes or subsystemdir/classes.
-1. The classname and filename for all namespaced classes must conform to the [[Automatic class loading|automatic class loading]] rules. The use of formal PHP namespaces in all new code is required.
+
+1. Classes belonging to a namespace must be created in a classes directory, for example:
+  - in the `mod_forum` plugin classes should be placed in `mod/forum/classes`;
+  - for core code, classes should be placed in `lib/classes`; or
+  - for a core subsystem, classes should be placed in `subsystemdir/classes`.
+1. The classname and filename for all namespaced classes must conform to the [[Automatic class loading|automatic class loading]] rules. The use of formal PHP namespaces is **required** in all new code.
 1. Use at most one namespace declaration per file.
 
-GOOD:
-```php
-<? // This is a file mod/porridge/classes/local/equipment/spoon.php
+<ValidExample>
+
+```php title="mod/porridge/classes/local/equipment/spoon.php"
+<?php
 
 namespace mod_porridge\local\equipment;
 
 class spoon {
     // Your code here.
 }
-
-// End of file.
 ```
 
+</ValidExample>
+
 BAD:
-```php
+
+<InvalidExample>
+
+```php title="mod/porridge/classes/local/equipment/spoon.php"
+<?php
 namespace mod_porridge\local\equipment;
 
 class spoon {
@@ -411,74 +621,95 @@ class eat {
 // End of file.
 ```
 
-The namespace declaration may be preceded with a doc block.
+</InvalidExample>
 
-The [class naming](#classes) rules also apply to the names for each level of namespace.
+#### Further notes
 
-The namespace declaration must be the first non-comment line in the file, followed by one blank line, followed by the (optional)
-"use" statements, one per line, followed by one blank line.
+- The namespace declaration _may_ be preceded with a doc block.
+- The [class naming](#classes) rules also apply to the names for each level of namespace.
+- The namespace declaration must be the first non-comment line in the file, followed by one blank line, followed by any (optional)
+`use` statements
+- Each `use` statement must be on its own line.
+- There should be a single empty line following the final `use` statement.
+- The use of `use` statements should be made to avoid repetition of long namespaces in the code.
+- Do not import an entire namespace with a `use` statement, import individual classes only.
+- Do not alias class imports (`use XXX as YYY;`) unless it is absolutely required to resolve a conflict.
+- It is recommended that class aliases be alphabetically sorted.
 
-"use" statements should be used to avoid repetition of long namespaces in the code.
+<ValidExample>
 
-Do not import an entire namespace with a "use" statement, import individual classes only.
-
-Do not use named imports ("use XXX as YYY;") unless it is absolutely required to resolve a conflict.
-
-GOOD:
-```phpuse mod_porridge\local\equipment\spoon; // One class per line.
+```php title="An example of correct class importing"
+<?php
 use mod_porridge\local\equipment\bowl; // One class per line.
+use mod_porridge\local\equipment\spoon; // One class per line.
 
 ```
 
-BAD:
-```phpuse mod_porridge\local\equipment\spoon, mod_porridge\local\equipment\bowl; // Multiple classes per line.
+</ValidExample>
+
+<InvalidExample>
+
+```php title="Examples of incorrect class importing"
+<?php
+
+use mod_porridge\local\equipment\spoon, mod_porridge\local\equipment\bowl; // Multiple classes per line.
 use mod_porridge\local; // Importing an entire namespace.
 use core; // Importing an entire namespace.
 use mod_breakfast; // Importing an entire namespace.
 use mod_porridge\local\equipment\spoon as silverspoon; // Named import with no good reason.
-
 ```
 
-Never use the __NAMESPACE__ magic constant.
+</InvalidExample>
 
-Never use the "namespace" keyword anywhere but the namespace declaration.
+- Never use the `__NAMESPACE__` magic constant.
+- Never use the `namespace` keyword anywhere but the namespace declaration.
 
-BAD:
-```php
+<InvalidExample>
+
+```php title="Inocrrect: An example of the namespace keyword used incorrectly"
 $obj = new namespace\Another();
 ```
 
-Do not use bracketed "namespace" blocks.
+</InvalidExample>
 
-BAD:
-```php
+- Do not use bracketed "namespace" blocks.
+
+<InvalidExample>
+
+```php title="Incorrect: An example of a bracketed namespace"
 namespace {
     // Global scope.
 }
 ```
 
-Namespaces MUST only be used for classes existing in a subfolder of "classes".
+</InvalidExample>
 
-For new classes - the maximum level of detail should be used when deciding the namespace.
+- Namespaces *MUST* only be used for classes existing in a subfolder of `classes`.
+- For new classes - the maximum level of detail should be used when deciding the namespace.
 
-GOOD:
-```php
+<ValidExample>
+
+```php title="Correct: Use the maximum level of detail in the namespace"
 namespace xxxx\yyyy; // xxxx is the component, yyyy is the api.
 
 class zzzz {
 }
 ```
 
-Never use a leading backslash (\) in "namespace" and "use" statements.
+</ValidExample>
 
-Global functions called from namespaced code should never use a leading
-backslash (\). Classes from outside the current scope use the leading backslash
-or are imported by the "use" keyword. See
+- Never use a leading backslash (\) in "namespace" and "use" statements.
+- Global functions called from namespaced code should never use a leading
+backslash (`\`).
+  Classes from outside the current scope use the leading backslash or are
+  imported by the `use` keyword. See
 [PHP manual](https://www.php.net/manual/en/language.namespaces.fallback.php) for
 details.
 
-GOOD:
-```php
+<ValidExample>
+
+```php title="Correct: Examples of correct usages"
+<?php
 namespace mod_breakfast\local;
 
 use moodle_url;
@@ -489,8 +720,12 @@ $tasks = \core\task\manager::get_all_scheduled_tasks(); // Leading slash needed 
 $a = new \stdClass(); // Leading slash needed here.
 ```
 
-BAD:
-```php
+</ValidExample>
+
+<InvalidExample>
+
+```php title="Incorrect; Examples of incorrect usages"
+<?php
 namespace \mod_breakfast; // The leading backslash should not be here.
 
 use \core\task\manager; // The leading backslash should not be here.
@@ -498,36 +733,50 @@ use \core\task\manager; // The leading backslash should not be here.
 \get_string('xxxx', 'yyyy'); // The leading backslash should not be here.
 ```
 
+</InvalidExample>
+
 #### Parts of a namespace
 
 Given the following fully qualified name of a class:
 
-`\<level1>\<level2>\<level3>\...\<classname>`
+``` title="Anatomy of a namespace"
+\<level1>\<level2>\<level3>\...\<classname>
+```
 
-There are clear rules for what is allowable at each level of namespace. Only the first level is mandatory. Nested namespaces are used when the class implements some core API or when the plugin maintainer want to organise classes to separate namespaces within the plugin - see rules regarding the level2 for details.
+There are clear rules for what is allowable at each level of namespace.
+Only the first level is mandatory.
+Nested namespaces are used when the class implements some core API or when the plugin maintainer want to organise classes to separate namespaces within the plugin - see rules regarding the level2 for details.
 
 #### Rules for level1
 
-The first level MUST BE EITHER:
-- a full component name (e.g. "\mod_forum"). All classes using namespaces in a plugin MUST be contained in
-this level 1 namespace.
-or
-- "\core" for all core apis
+The first level, when used, **MUST** be _either_:
+
+- a full component name (for example `\mod_forum`).
+  All classes using namespaces in a plugin *MUST* be contained in this level 1
+  namespace; or
+- `\core` for all core apis
 
 #### Rules for level2
 
-The second level, when used, MUST BE EITHER:
-- The short name of a core API (must be defined on https://docs.moodle.org/dev/API). The classes in this namespace must either implement or use the API in some way.
-or
-- "\local" for any other classes in a component, if the maintainer wants to organise them further (note that for most components, it's probably enough to have all their own classes in the root level1 namespace only).
+The second level, when used, **MUST** be _either_:
+
+- The short name of a [core API](/docs/apiguides). 
+  The classes in this namespace must either implement or use the API in some way; or
+- `\local` for any other classes in a component, if the maintainer wants to organise them further (note that for most components, it's probably enough to have all their own classes in the root level1 namespace only).
 
 #### Rules for level3
 
-There are no rules limiting what can be used as a level 3 namespace. This is where a plugin or addon can make extensive use of
-namespaces with no chance of conflict with any other plugin or api, now and forever onwards.
+There are no rules limiting what can be used as a level 3 namespace.
+This is where a plugin or addon can make extensive use of namespaces with no
+chance of conflict with any other plugin or api, now and forever onwards.
 
-#### Namespaces within **/tests directories
-(agreed @ MDLSITE-4800)
+#### Namespaces within `**/tests` directories
+
+:::info
+
+These rules were agreed in {tracker}`MDLSITE-4800`
+
+:::
 
 - The use of namespaces is strongly recommended for unit tests.
 - When using namespaces, the namespace of the test class should match the namespace of the code under test.
@@ -536,12 +785,17 @@ namespaces with no chance of conflict with any other plugin or api, now and fore
 - Sub-namespaces are allowed, strictly following the general namespace rules for levels 2 & 3 above. Always trying to match as much as possible the namespace of the code being covered.
 - Sub-directory structure must match the namespace structure, but will be placed in the `tests` directory instead.
 
-Please note: auto-loading of tests is not supported (but autoloading the standard class from a test is).
+:::note
+
+Autoloading of tests is not supported (but autoloading the standard class from a test is).
+
+:::
 
 #### Examples
 
-GOOD:
-```php
+<ValidExample>
+
+```php title="Correct: Examples of correct namespaces"
 // Plugin's own namespace when not using nested namespaces (typical)
 // Namespace location: mod/breakfast/classes/
 // Test location: mod/breakfast/tests/
@@ -563,7 +817,10 @@ namespace mod_breakfast\local\utils;
 namespace mod_breakfast\event;
 ```
 
-BAD:
+</ValidExample>
+
+<InvalidExample>
+
 ```php
 namespace mymodule;                     // Violates the level1 rules - invalid component name
 namespace mod_breakfast\myutilities;    // Violates the level2 rules - invalid core API name
@@ -573,6 +830,8 @@ namespace mod_forum\test;               // While technically correct ("test" is 
                                         // level-2 to be covered. Only then it could be used.
 ```
 
+</InvalidExample>
+
 ## Strings
 
 Since string performance is not an issue in current versions of PHP, the main criteria for strings is readability.
@@ -581,22 +840,32 @@ Since string performance is not an issue in current versions of PHP, the main cr
 
 Always use single quotes when a string is literal, or contains a lot of double quotes (like HTML):
 
+<ValidExample>
+
 ```php
 $a = 'Example string';
 echo '<span class="'.s($class).'"></span>';
 $html = '<a href="http://something" title="something">Link</a>';
 ```
 
+</ValidExample>
+
 ### Double quotes
 
 These are a lot less useful in Moodle. Use double quotes when you need to include plain variables or a lot of single quotes.
+
+<ValidExample>
 
 ```php
 echo "<span>$string</span>";
 $statement = "You aren't serious!";
 ```
 
+</ValidExample>
+
 Complex SQL queries should be always enclosed in double quotes.
+
+<ValidExample>
 
 ```php
 $sql = "SELECT e.*, ue.userid
@@ -606,9 +875,13 @@ $sql = "SELECT e.*, ue.userid
          WHERE :now - u.lastaccess > e.customint2";
 ```
 
+</ValidExample>
+
 ### Variable substitution
 
 Variable substitution can use either of these forms:
+
+<ValidExample>
 
 ```php
 $greeting = "Hello $name, welcome back!";
@@ -616,47 +889,77 @@ $greeting = "Hello $name, welcome back!";
 $greeting = "Hello {$name}, welcome back!";
 ```
 
+</ValidExample>
+
 ### String concatenation
 
 Strings must be concatenated using the "." operator.
 
-```php
-$longstring = $several.$short.'strings';
-```
-
-If the lines are long, break the statement into multiple lines to improve readability.  In these cases, put the "dot" at the end of each line.
+<ValidExample>
 
 ```php
-$string = 'This is a very long and stupid string because '.$editorname.
-          " couldn't think of a better example at the time.";
+$longstring = $several . $short . 'strings';
 ```
+
+</ValidExample>
+
+If the lines are long, break the statement into multiple lines to improve readability. In these cases, put the "dot" at the end of each line.
+
+<ValidExample>
+
+```php
+$string = 'This is a very long and stupid string because ' . $editorname .
+    " couldn't think of a better example at the time.";
+```
+
+</ValidExample>
+
 The dot operator may be used without any space to either side (as shown in the above examples), or with spaces on each side; whichever the developer prefers.
 
 ### Language strings
 
 #### Capitals
 
-Language strings should "Always look like this" and "Never Like This Example".
-
 Capitals should only be used when:
+
 1. starting a sentence, or
 1. starting a proper name, like Moodle.
 
+```
+// Correct.
+Always look like this example.
+
+// Incorrect.
+Never Like This Example.
+```
+
 #### Structure
 
-Strings should not be designed for UI concatenation, as it may cause problems in other languages.   Each string should stand alone.
+Strings should not be designed for UI concatenation, as it may cause problems in other languages. Each string should stand alone.
 
-BAD:
- $string['overduehandling'] = 'When time expires';
- $string['overduehandlingautosubmit'] = 'the attempt is submitted automatically';
- $string['overduehandlinggraceperiod'] = 'there is a grace period in which to submit the attempt, but not answer more questions';
- $string['overduehandlingautoabandon'] = 'that is it. The attempt must be submitted before time expires, or it is not counted';
+<InvalidExample>
 
-GOOD:
- $string['overduehandling'] = 'Time expiry behaviour';
- $string['overduehandlingautosubmit'] = 'Unfinished attempts will be auto-submitted immediately';
- $string['overduehandlinggraceperiod'] = 'Unfinished attempts have a short grace period to be submitted for grading';
- $string['overduehandlingautoabandon'] = 'Unfinished attempts are immediately discarded';
+```php title="Strings should not be designed to be concatenated to make a sentence"
+// Incorrect.
+$string['overduehandling'] = 'When time expires';
+$string['overduehandlingautosubmit'] = 'the attempt is submitted automatically';
+$string['overduehandlinggraceperiod'] = 'there is a grace period in which to submit the attempt, but not answer more questions';
+$string['overduehandlingautoabandon'] = 'that is it. The attempt must be submitted before time expires, or it is not counted';
+```
+
+</InvalidExample>
+
+<ValidExample>
+
+```php title="Strings should be complete without concatenation"
+// Correct.
+$string['overduehandling'] = 'Time expiry behaviour';
+$string['overduehandlingautosubmit'] = 'Unfinished attempts will be autosubmitted immediately';
+$string['overduehandlinggraceperiod'] = 'Unfinished attempts have a short grace period to be submitted for grading';
+$string['overduehandlingautoabandon'] = 'Unfinished attempts are immediately discarded';
+```
+
+</ValidExample>
 
 #### Whitespace
 
@@ -668,20 +971,32 @@ Language strings should not contain or even rely on any leading or trailing whit
 
 When declaring arrays, a trailing space must be added after each comma delimiter to improve readability:
 
+<ValidExample>
+
 ```php
 $myarray = [1, 2, 3, 'Stuff', 'Here'];
 ```
 
+</ValidExample>
+
 Multi-line indexed arrays are fine, but pad each successive lines as above with an 4-space indent:
+
+<ValidExample>
 
 ```php
 $myarray = [1, 2, 3, 'Stuff', 'Here',
     $a, $b, $c, 56.44, $d, 500];
 ```
 
+</ValidExample>
+
 :::note
+
 The example above also can be written as follows:<br/>
 (with special attention to the last line having a trailing comma to extend the list of items later with a cleaner diff)
+
+
+<ValidExample>
 
 ```php
 $myarray = [
@@ -689,6 +1004,9 @@ $myarray = [
     $a, $b, $c, 56.44, $d, 500,
 ];
 ```
+
+</ValidExample>
+
 :::
 
 In any case, brackets and newlines need to be balanced, irrespectively of the number of elements per line.
@@ -697,6 +1015,8 @@ In any case, brackets and newlines need to be balanced, irrespectively of the nu
 
 Use multiple lines if this helps readability. For example:
 
+<ValidExample>
+
 ```php
 $myarray = [
     'firstkey' => 'firstvalue',
@@ -704,19 +1024,21 @@ $myarray = [
 ];
 ```
 
+</ValidExample>
+
 ## Classes
 
 ### Class declarations
 
 - Classes must be named according to Moodle's naming conventions.
 - Classes must go under their respective "component/classes" dir to get the benefits of autoloading and [namespacing](#namespaces). There aren't such luxuries out from there.
-- Each php file will contain only one class (or interface, or trait...). Unless it's part of old APIs where multi-artifact files were allowed.
+- Each php file will contain only one class (or interface, or trait, etc.). Unless it's part of old APIs where multi-artifact files were allowed.
 - The brace should always be written on the line beside the class name.
 - Every class must have a documentation block that conforms to the PHPDocumentor standard.
 - All code in a class must be indented with 4 spaces.
-- Placing additional code ("side-effects") in class files is only permitted to require artifacts not provided via autoloading (old classes or libs out from the "classes" directories and not loaded by Moodle's bootstrap). In those cases, the use of the [`MOODLE_INTERNAL` check](#require--include) will be required.
+- Placing additional code (side-effects) in class files is only permitted to require artifacts not provided via autoloading (old classes or libs out from the "classes" directories and not loaded by Moodle's bootstrap). In those cases, the use of the [`MOODLE_INTERNAL` check](#require--include) will be required.
 
-: An example:
+<ValidExample>
 
 ```php
 /**
@@ -734,8 +1056,12 @@ class sample_class {
 }
 ```
 
+</ValidExample>
+
 :::note
+
 The classes PHPDoc style is defined with more detail in the [Documentation and comments / Classes](#phpdoc-classes) section in this document.
+
 :::
 
 ### Class member variables
@@ -747,6 +1073,7 @@ Any variables declared in a class must be listed at the top of the class, above 
 The var construct is not permitted. Member variables always declare their visibility by using one of the **private**, **protected**, or **public** modifiers. Giving access to member variables directly by declaring them as public is permitted but discouraged in favor of accessor methods (set/get).
 
 ## Functions and methods
+
 ### Function and method declaration
 
 Functions must be named according to the Moodle function naming conventions.
@@ -760,6 +1087,8 @@ Don't leave spaces between the function name and the opening parenthesis for the
 The return value must not be enclosed in parentheses. This can hinder readability, in additional to breaking code if a method is later changed to return by reference.
 
 Return should only be one data type. It is discouraged to have multiple return types
+
+<ValidExample>
 
 ```php
 /**
@@ -778,32 +1107,46 @@ class sample_class {
 }
 ```
 
+</ValidExample>
+
 ### Function and method usage
 
 Function arguments should be separated by a single trailing space after the comma delimiter.
+
+<ValidExample>
 
 ```php
 three_arguments(1, 2, 3);
 ```
 
+</ValidExample>
+
 ### Magic methods
+
 Magic methods are heavily discouraged, justification will be required when used. Note: lazyness will not be a valid argument.
 
-(See MDL-52634 for discussion of rationale)
+(See {tracker}`MDL-52634` for discussion of rationale)
 
 ## Control statements
 
-In general, use white space liberally between lines and so on, to add clarity.
+In general, use white space liberally between lines to add clarity.
 
 ### If / else
 
-Put a space before and after the control statement in brackets, and separate the operators by spaces within the brackets.  Use inner brackets to improve logical grouping if it helps.
+Put a space before and after the control statement in brackets, and separate the operators by spaces within the brackets. Use inner brackets to improve logical grouping if it helps.
 
 Indent with four spaces.
 
--Don't use elseif!*
+:::note Do not use `elseif`
+
+Always use the `else if` variant
+
+:::
+
 
 Always use braces (even if the block is one line and PHP doesn't require it). The opening brace of a block is always placed on the same line as its corresponding statement or declaration.
+
+<ValidExample>
 
 ```php
 if ($x == $y) {
@@ -815,11 +1158,15 @@ if ($x == $y) {
 }
 ```
 
+</ValidExample>
+
 ### Switch
 
-Put a space before and after the control statement in brackets, and separate the operators by spaces within the brackets.  Use inner brackets to improve logical grouping if it helps.
+Put a space before and after the control statement in brackets, and separate the operators by spaces within the brackets. Use inner brackets to improve logical grouping if it helps.
 
-Always indent with four spaces.  Content under each case statement should be indented a further four spaces.
+Always indent with four spaces. Content under each case statement should be indented a further four spaces.
+
+<ValidExample>
 
 ```php
 switch ($something) {
@@ -834,9 +1181,13 @@ switch ($something) {
 }
 ```
 
+</ValidExample>
+
 ### Foreach
 
 As above, uses spaces like this:
+
+<ValidExample>
 
 ```php
 foreach ($objects as $key => $thing) {
@@ -844,74 +1195,102 @@ foreach ($objects as $key => $thing) {
 }
 ```
 
+</ValidExample>
+
 ### Ternary Operator
 
 The ternary operator is only permitted to be used for **short**, **simple to understand** statements. If the statement can't be understood in one sentance, use an if statement instead.
 
 Whitespace must be used around the operators to make it clear where the operation is taking place.
 
-GOOD:
+<ValidExample>
+
 ```php
 $username = isset($user->username) ? $user->username : *; **
 $users = is_array($users) ? $users : [$users];
 ```
+</ValidExample>
 
-BAD:
+<InvalidExample>
+
 ```php
 $toload = (empty($CFG->navshowallcourses))?self::LOAD_ROOT_CATEGORIES:self::LOAD_ALL_CATEGORIES;
 $coefstring = ($coefstring==* or $coefstring=='aggregationcoefextrasum') ? 'aggregationcoefextrasum' : 'aggregationcoef';
 ```
 
+</InvalidExample>
+
 :::note
+
 Since PHP 7.0, many of those `isset()` ternaries can be changed to use the new shorthand [null coalescing operator](https://www.php.net/manual/en/migration70.new-features.php#migration70.new-features.null-coalesce-op) so, the above is equivalent to:
+
 ```php
 $username = $user->username ?? *;
 ```
+
 :::
 
 ## Require / include
 
 Each file that is accessed via browser should start by including the main config.php file.
 
+<ValidExample>
+
 ```php
 require(__DIR__ . '/../../config.php');
 ```
 
+</ValidExample>
+
 Any other include/require should use a path starting with <tt>__DIR__</tt> or an absolute path starting with <tt>$CFG->dirroot</tt> or <tt>$CFG->libdir</tt>. Relative includes starting with "../" can [sometimes behave strangely under PHP](https://www.php.net/manual/en/function.include.php), so should not be used. Our [[CLI scripts]] must not use relative config.php paths starting with "../".
 
 For library files in normal usage, require_once should be used (this is different from config.php which should always use 'require' as above). Examples:
+
+<ValidExample>
+
 ```php
 require_once(__DIR__ . '/locallib.php');
 require_once($CFG->libdir . '/filelib.php');
 ```
 
+</ValidExample>
+
 Includes should generally only be done at the top of files or inside functions/methods that need them. Using include/require in the middle of a file in global scope very hard to audit the security of the code.
 
-All other scripts with the exception of imported 3rd party libraries and files without *side-effects** (i.e. single class definitions, interfaces or traits), should use following code at the very top to prevent direct execution which might reveal error messages on misconfigured production servers.
+All other scripts with the exception of imported 3rd party libraries and files without *side-effects* (that is single class definitions, interfaces or traits), should use following code at the very top to prevent direct execution which might reveal error messages on misconfigured production servers.
 
 ```php
 defined('MOODLE_INTERNAL') || die();
 ```
 
-<nowiki>*</nowiki>*side-effects*: Any global scope code not being: a) namespace and use statements or b) namespace constants or c) strict_types declarations (declarations in general).
+:::info Side-effects
+
+The term side-effects refers to any global scope code not being:
+
+- the `namespace`;
+- a `use` statements;
+- namespace constants; or
+- `strict_types` declarations (declarations in general).
+
+:::
 
 Please note that the existence or absence of side-effects in a file only affects as explained above, at code level. It shouldn't be considered in other parts of the coding style unless specifically mentioned.
 
 ## Documentation and comments
 
-Code documentation explains the code flow and the purpose of functions and variables.  Use it whenever practical.
+Code documentation explains the code flow and the purpose of functions and variables. Use it whenever practical.
 
 ### PHPDoc
 
-Moodle stays as close as possible to "standard" [PHPDoc format](https://www.phpdoc.org/) to document our files, classes and functions.  This helps IDEs (like Netbeans or Eclipse) work properly for Moodle developers, and also allows us to generate web documentation automatically.
+Moodle stays as close as possible to "standard" [PHPDoc format](https://www.phpdoc.org/) to document our files, classes and functions. This helps IDEs (like Netbeans or Eclipse) work properly for Moodle developers, and also allows us to generate web documentation automatically.
 
-PHPDoc has a number of tags that can be used in different places (files, classes and functions).  We have some particular rules for using them in Moodle that you must follow:
+PHPDoc has a number of tags that can be used in different places (files, classes and functions). We have some particular rules for using them in Moodle that you must follow:
 
 #### Types
 
-Some of the tags below (@param, @return...) do require the specification of a valid php type and a description. All these are allowed:
+Some of the tags below (@param, @return, etc.) do require the specification of a valid php type and a description. All these are allowed:
 
-- PHP primitive types: int, bool, string...
+- PHP primitive types: int, bool, string, etc.
 - PHP complex types: array, stdClass (not Array, object).
 - PHP classes:full or relative (to current namespace) class names.
 - true, false, null (always lowercase).
@@ -921,114 +1300,198 @@ Some of the tags below (@param, @return...) do require the specification of a va
 - void: for methods with a explicit empty "return" statement.
 
 Also, there are some basic rules about how to use those types:
+
 - We use [short type names](https://www.php.net/manual/en/language.types.type-juggling.php) (bool instead of boolean, int instead of integer).
-- With cases represented as array of given type, it's highly recommended to document them as type[] instead of the simpler and less informative "array" alternative (e.g. <tt>int[]</tt> or <tt>stdClass[]</tt>).
-- When multiple different types are possible, they must be separated by a vertical bar (pipe) (e.g. <tt>@return int|false</tt>).
+- With cases represented as array of given type, it's highly recommended to document them as type[] instead of the simpler and less informative "array" alternative (for example <tt>int[]</tt> or <tt>stdClass[]</tt>).
+- When multiple different types are possible, they must be separated by a vertical bar (pipe) (for example <tt>@return int|false</tt>).
 - All primitives and keywords must be lowercase. The case of the complex types and classes must match the original.
 
 #### Tags
 
-##### @copyright
+##### `@copyright`
 
-These include the year and copyright holder (creator) of the original file.  Do not change these in existing files!
+These include the year and copyright holder (creator) of the original file. Do not change these in existing files!
 
+<ValidExample>
+
+```
   @copyright 2008 Kim Bloggs
+```
 
-##### @license
+</ValidExample>
+
+##### `@license`
 
 These must be GPL v3+ and use this format:
 
-  @license https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+<ValidExample>
 
-##### @param
+```
+  @license https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+```
+
+</ValidExample>
+
+##### `@param`
 
 Don't put hyphens or anything fancy after the variable name, just a space.
 
+<ValidExample>
+
+```
   @param [[#Types|type]] $name Description.
+```
 
-##### @return
+</ValidExample>
 
-The @return tag is mandatory if the function has a return statement, but can be left out if it does not have one.
+##### `@return`
+
+The `@return` tag is mandatory if the function has a return statement, but can be left out if it does not have one.
 
 The description portion is optional, it can be left out if the function is simple and already describes what is returned.
 
+<ValidExample>
+
+```
   @return [[#Types|type]] Description.
+```
 
-##### @var
+</ValidExample>
 
-The @var tag is used to document class properties.
+##### `@var`
 
+The `@var` tag is used to document class properties.
+
+<ValidExample>
+
+```
   @var [[#Types|type]] Description.
+```
+</ValidExample>
 
 Exceptionally, when none of the available [[#Types|types]] define the returned value, inline @var phpdocs (within the body of the methods) providing type hinting are allowed to the returned type. Don't abuse!
 
-##### @uses
+##### `@uses`
 
 If a function uses die or exit, please add this tag to the docblock to help developers know this function could terminate the page:
 
-  @uses exit
+<ValidExample>
 
-##### @access
+```
+  @uses exit
+```
+</ValidExample>
+
+##### `@access`
 
 The access can be used to specify access control for an element
 
 1. Should only be used when the method definition does not already specify access control.
 1. In the case of functions, specifying public access is redundant and so should be avoided.
 
+<ValidExample>
+
+```
   @access private
+```
+</ValidExample>
 
-##### @package
+##### `@package`
 
-The package tag should always be used to label php files with the correct [[Frankenstyle]] component name.  Full rules are explained on that page, but in summary:
+The package tag should always be used to label php files with the correct [[Frankenstyle]] component name. Full rules are explained on that page, but in summary:
 
-1. If the file is part of any component plugin, then use the plugin component name (eg **mod_quiz** or **gradereport_xls**)
-1. If the file is part of a core subsystem then it will be core_xxxx where xxxx is the name defined in get_core_subsystems().  (eg **core_enrol** or **core_group**)
+1. If the file is part of any component plugin, then use the plugin component name (for example **mod_quiz** or **gradereport_xls**)
+1. If the file is part of a core subsystem then it will be core_xxxx where xxxx is the name defined in get_core_subsystems(). (for example **core_enrol** or **core_group**)
 1. If the file is one of the select few files in core that are not part of a subsystem (such as lib/moodlelib.php) then it just as a package of **core**.
 1. Each file can only be part of ONE package.
 
-(We do not have standards for @subpackage at all.  You can use within your @package how you like.)
+(We do not have standards for `@subpackage` at all. You can use within your @package how you like.)
 
+<ValidExample>
+
+```
   @package gradereport_xls
+```
 
-##### @category
+</ValidExample>
 
-We use @category only to highlight the public classes, functions or files that are part of one of our [[Core APIs]], or that provide good example implementations of a Core API.  The value must be one of the ones on the [[Core APIs]] page.
+##### `@category`
 
+We use `@category` only to highlight the public classes, functions or files that are part of one of our [[Core APIs]], or that provide good example implementations of a Core API. The value must be one of the ones on the [[Core APIs]] page.
+
+<ValidExample>
+
+```php
   @category preferences
+```
 
-##### @since
+</ValidExample>
 
-When adding a new classes or function to the Moodle core libraries (or adding a new method to an existing class), use a @since tag to document which version of Moodle it was added in. For example:
+##### `@since`
 
+When adding a new classes or function to the Moodle core libraries (or adding a new method to an existing class), use a `@since` tag to document which version of Moodle it was added in. For example:
+
+<ValidExample>
+
+```php
   @since Moodle 2.1
+```
 
-##### @see
+</ValidExample>
 
-If you want to refer the user to another related element (include, class, function, define, method, variable), but not to URLs, then you can use @see.
+##### `@see`
 
+If you want to refer the user to another related element (include, class, function, define, method, variable), but not to URLs, then you can use `@see`.
+
+<ValidExample>
+
+```
   @see some_other_function()
+```
+
+</ValidExample>
 
 This tag can be used inline too, within phpdoc comments.
 
+<ValidExample>
+
+```php
    /**
     * This function uses {@see get_string()} to obtain the currency names...
     * .....
+```
 
-##### @link
+</ValidExample>
+
+##### `@link`
 
 If you want to refer the user to an external URL, but not to related elements, use @link.
 
+<ValidExample>
+
+```
   @link https://docs.moodle.org/dev/Core_APIs
+```
+
+</ValidExample>
 
 This tag can be used inline too, within phpdoc comments.
 
+<ValidExample>
+
+```php
    /**
     * For details about the implementation below, visit {@link https://docs.moodle.org/dev/Core_APIs} and read...
     * .....
+```
 
-##### @deprecated (and @todo)
+</ValidExample>
 
-When deprecating an old API, use a @deprecated tag to document which version of Moodle it was deprecated in, and add @todo and @see if possible.  Make sure to mention relevant MDL issues.  For example:
+##### `@deprecated` (and `@todo`)
+
+When deprecating an old API, use a `@deprecated` tag to document which version of Moodle it was deprecated in, and add `@todo` and `@see` if possible. Make sure to mention relevant MDL issues. For example:
+
+<ValidExample>
 
 ```php
 /**
@@ -1039,9 +1502,11 @@ When deprecating an old API, use a @deprecated tag to document which version of 
  */
 ```
 
-If it is important that developers update their code, consider also adding a debugging('...', DEBUG_DEVELOPER); call to repeat the deprecated message. If the old function can no longer be supported at all, you may have to throw a coding_exception. There are examples of the various options in lib/deprecatedlib.php.
+</ValidExample>
 
-##### @throws
+If it is important that developers update their code, consider also adding a `debugging('...', DEBUG_DEVELOPER);` call to repeat the deprecated message. If the old function can no longer be supported at all, you may have to throw a coding_exception. There are examples of the various options in `lib/deprecatedlib.php`.
+
+##### `@throws`
 
 This tag is valid and can be used optionally to indicate the method or function will throw and exception. This is to help developers know they may have to handle the exceptions from such functions.
 
@@ -1049,13 +1514,13 @@ This tag is valid and can be used optionally to indicate the method or function 
 
 There are some tags that are only allowed within some contexts and not globally. More precisely:
 
-- @Given, @When, @Then, within the [[Acceptance testing#Adding steps definitions|behat steps definitions]].
-- @covers, @coversDefaultClass, @coversNothing, @uses to better control coverage within [[Writing PHPUnit tests#Generators|unit tests]].
-- @dataProvider and @testWith, to provide example data and expectations, within [[Writing PHPUnit tests#Generators|unit tests]].
-- @depends, to express dependencies between tests, where each producer returned data in passed to consumers. See [@depends examples](https://phpunit.readthedocs.io/en/9.5/writing-tests-for-phpunit.html#writing-tests-for-phpunit-examples-stacktest2-php) for more information.
-- @group, for easier collecting unit tests together, following the guidelines in the [[PHPUnit#Using_the_.40group_annotation|PHPUnit MoodleDocs]].
-- @requires, to specify unit test requirements and skip if not fulfilled. See [@requires usages](https://phpunit.readthedocs.io/en/9.5/incomplete-and-skipped-tests.html#incomplete-and-skipped-tests-requires-tables-api) for more information.
-- @runTestsInSeparateProcesses and @runInSeparateProcess, to execute an individual test or a testcase in isolation. To be used only when strictly needed.
+- `@Given`, `@When`, `@Then`, within the [[Acceptance testing#Adding steps definitions|behat steps definitions]].
+- `@covers`, `@coversDefaultClass`, `@coversNothing`, `@uses` to better control coverage within [[Writing PHPUnit tests#Generators|unit tests]].
+- `@dataProvider` and `@testWith`, to provide example data and expectations, within [[Writing PHPUnit tests#Generators|unit tests]].
+- `@depends`, to express dependencies between tests, where each producer returned data in passed to consumers. See [`@depends` examples](https://phpunit.readthedocs.io/en/9.5/writing-tests-for-phpunit.html#writing-tests-for-phpunit-examples-stacktest2-php) for more information.
+- `@group`, for easier collecting unit tests together, following the guidelines in the [[PHPUnit#Using_the_.40group_annotation|PHPUnit MoodleDocs]].
+- `@requires`, to specify unit test requirements and skip if not fulfilled. See [`@requires` usages](https://phpunit.readthedocs.io/en/9.5/incomplete-and-skipped-tests.html#incomplete-and-skipped-tests-requires-tables-api) for more information.
+- `@runTestsInSeparateProcesses` and `@runInSeparateProcess`, to execute an individual test or a testcase in isolation. To be used only when strictly needed.
 
 ### Files
 
@@ -1063,12 +1528,12 @@ All files that contain PHP code should contain, without any blank line after the
 
 1. short one-line description of the file
 1. longer description of the file
-1. @package tag (required)
-1. @category tag (only when everything in the file is related to one of the [[Core APIs]])
-1. @copyright (required)
-1. @license (required)
+1. `@package` tag (required)
+1. `@category` tag (only when everything in the file is related to one of the [[Core APIs]])
+1. `@copyright` (required)
+1. `@license` (required)
 
-For files containing only one artifact, the file phpdc block is optional as long as the artifact (class, interface, trait...) is documented. Read the following "Classes" section about that case.
+For files containing only one artifact, the file phpdoc block is optional as long as the artifact (class, interface, trait, etc.) is documented. Read the following "Classes" section about that case.
 
 ```php
 <?php
@@ -1081,11 +1546,11 @@ For files containing only one artifact, the file phpdc block is optional as long
 //
 // Moodle is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+// along with Moodle. If not, see <https://www.gnu.org/licenses/>.
 
 /**
  * This is a one-line short description of the file.
@@ -1104,6 +1569,8 @@ For files containing only one artifact, the file phpdc block is optional as long
 
 All classes must have a complete docblock like this:
 
+<ValidExample>
+
 ```php
 /**
  * Short description for class.
@@ -1118,7 +1585,9 @@ All classes must have a complete docblock like this:
 class policy_issue {
 ```
 
-For files containing only one artifact (class, interface, trait...), specifically for all the files within <tt>classes</tt> directories, but also any other file fulfilling the condition anywhere else, it will be enough with the class phpdoc block. The file phpdoc block will be considered optional at all effects, giving to the class one precedence.
+</ValidExample>
+
+For files containing only one artifact (class, interface, trait, etc.), specifically for all the files within <tt>classes</tt> directories, but also any other file fulfilling the condition anywhere else, it will be enough with the class phpdoc block. The file phpdoc block will be considered optional at all effects, giving to the class one precedence.
 
 The [[#@package|@package]], [[#@copyright|@copyright]] and [[#@license|@license]] tags (and the optional [[#@category|@category]] tag ), as shown in the example above, must be present always in the file (in whichever docblock, but all together).
 
@@ -1126,13 +1595,21 @@ The [[#@package|@package]], [[#@copyright|@copyright]] and [[#@license|@license]
 
 All properties should have a docblock with the following minimum information:
 
+<ValidExample>
+
 ```php
 class example {
     /** @var string This variable does something */
     protected $something;
 }
 ```
+
+</ValidExample>
+
 or
+
+<ValidExample>
+
 ```php
 class example {
     /**
@@ -1143,7 +1620,12 @@ class example {
     protected $something;
 }
 ```
+
+</ValidExample>
+
 Even if there are several properties all sharing something in common, do not use [DocBlock templates](https://en.wikipedia.org/wiki/PHPDoc#DocBlock_Templates). Instead, document every property explicitly as in the following example:
+
+<ValidExample>
 
 ```php
 class zebra {
@@ -1158,9 +1640,13 @@ class zebra {
 }
 ```
 
+</ValidExample>
+
 ### Constants
 
 Class constants should be documented in the following way:
+
+<ValidExample>
 
 ```php
 class sam {
@@ -1171,16 +1657,19 @@ class sam {
 }
 ```
 
+</ValidExample>
 
 ### Functions
 
 All functions and methods should have a complete docblock like this:
 
+<ValidExample>
+
 ```php
 /**
  * The description should be first, with asterisks laid out exactly
  * like this example. If you want to refer to a another function,
- * use @see as below.   If it's useful to link to Moodle
+ * use @see as below. If it's useful to link to Moodle
  * documentation on the web, you can use a @link below or also
  * inline like this {@link https://docs.moodle.org/dev/something}
  * Then, add descriptions for each parameter and the return value as follows.
@@ -1193,13 +1682,17 @@ All functions and methods should have a complete docblock like this:
  */
 ```
 
-You must include a description even if it appears to be obvious from the @param and/or @return lines.
+</ValidExample>
 
-An exception is made for overridden methods which make no change to the meaning of the parent method and maintain the same arguments/return values. In this case you should omit the comment completely. Use of the @inheritdoc or @see tags is explicitly forbidden as a replacement for any complete docblock.
+You must include a description even if it appears to be obvious from the `@param` and/or `@return` lines.
+
+An exception is made for overridden methods which make no change to the meaning of the parent method and maintain the same arguments/return values. In this case you should omit the comment completely. Use of the `@inheritdoc` or `@see` tags is explicitly forbidden as a replacement for any complete docblock.
 
 ### Defines
 
 All defines should be documented in the following way:
+
+<ValidExample>
 
 ```php
 /**
@@ -1213,9 +1706,16 @@ define('PARAM_INT', 'int');
 define('PARAM_ALPHANUM', 'alphanum');
 ```
 
+</ValidExample>
+
 ### Inline comments
 
-Inline comments must use the "// " (2 slashes + whitespace) style, laid out neatly so that it fits among the code and lines up with it. The first line of the comment must begin with a capital letter (or a digit, or '...') and the comment must end with a proper punctuation character. Permitted final characters are '.', '?' or '!'.
+<!-- vale Microsoft.Ellipses = NO -->
+Inline comments must use the "// " (2 slashes + whitespace) style, laid out neatly so that it fits among the code and lines up with it.
+The first line of the comment must begin with a capital letter (or a digit, or '...') and the comment must end with a proper punctuation character. Permitted final characters are '.', '?' or '!'.
+<!-- vale Microsoft.Ellipses = YES -->
+
+<ValidExample>
 
 ```php
 function forum_get_ratings_mean($postid, $scale, $ratings = null) {
@@ -1238,9 +1738,17 @@ function forum_get_ratings_mean($postid, $scale, $ratings = null) {
         }
 ```
 
+</ValidExample>
+
+<ValidExample>
+
 ```php title="An example of correct single-line comment styling"
 // Comment explaining this piece of code.
 ```
+
+</ValidExample>
+
+<InvalidExample>
 
 ```php title="Example of incorrect commenting"
 /*  Comment explaining this piece of code. */
@@ -1248,15 +1756,21 @@ function forum_get_ratings_mean($postid, $scale, $ratings = null) {
 // comment explaining this piece of code (without capital letter and punctuation)
 ```
 
-If your comment is due to some MDL issue, please feel free to include the correct MDL-12345 in your comment.  This makes it easier to track down decisions and discussions about things.
+</InvalidExample>
+
+If your comment is due to some MDL issue, please feel free to include the correct MDL-12345 in your comment. This makes it easier to track down decisions and discussions about things.
 
 #### Using TODO
 
-This is especially important if you know an issue still exists in that code that should be dealt with later.  Use a TODO along with a MDL code to mark this.  For example:
+This is especially important if you know an issue still exists in that code that should be dealt with later. Use a TODO along with a MDL code to mark this. For example:
+
+<ValidExample>
 
 ```php
 // TODO MDL-12345 This works but is a bit of a hack and should be revised in future.
 ```
+
+</ValidExample>
 
 If you have a big task that is nearly done, apart a few TODOs, and you really want to mark the big task as finished, then you should file new tracker tasks for each TODO and change the TODOs comments to point at the new issue numbers.
 
@@ -1275,7 +1789,9 @@ Use exceptions to report errors, especially in library code.
 Throwing an exception has almost exactly the same effect as calling print_error(), but it is more flexible. For example, the caller can choose to catch the exception and handle it in some way. It also makes it easier to write unit tests.
 
 :::note
+
 Since 2021, it has been [agreed to deprecate `print_error()`](https://tracker.moodle.org/browse/MDL-69936) and, instead, to `throw moodle_exception()` is the correct way to proceed.
+
 :::
 
 Any exception that is not caught will trigger an appropriate call to print_error, to report the problem to the user. Exceptions "error codes" will be translated only when they are meant to be shown to final users.
@@ -1284,7 +1800,7 @@ Do not abuse exceptions for normal code flow. Exceptions should only be used in 
 
 ### Exception classes
 
-We have a set of custom exception classes. The base class is moodle_exception. You will see that the arguments you pass to new moodle_exception(...) are very similar to the ones you would pass to print_error. There are more specific subclasses for particular types of error.
+We have a set of custom exception classes. The base class is moodle_exception. You will see that the arguments you pass to new `moodle_exception(...)` are very similar to the ones you would pass to print_error. There are more specific subclasses for particular types of error.
 
 To get the full list of exception types, search for the regular expression 'class +\w+_exception +extends' or ask your IDE to list all the subclasses of moodle_exception.
 
@@ -1297,6 +1813,7 @@ A few notable exception types:
 ; file_exception: thrown by the File API.
 
 ## Dangerous functions and constructs
+
 PHP includes multiple questionable features that are highly discouraged because they are very often source of serious security problems.
 
 1. do not use *eval()* function - language packs are exception (to be solved in future).
@@ -1310,8 +1827,8 @@ Way before this coding-style guide was defined and agreed, a lot of code had bee
 
 In any case, in order to normalize the (progressive, non-critical) transition, a policy issue (MDL-43233) was created and agreed about. And these are the rules to apply to coding-style only changes:
 
-1. Related coding-style changes (same lines, a variable within a method/function, adjacent comments...) within a real issue are allowed.
-1. Unrelated coding-style changes (other methods, blocks of code, comments...) within a real issue are only accepted for master and in a separate commit.
+1. Related coding-style changes (same lines, a variable within a method/function, adjacent comments, etc.) within a real issue are allowed.
+1. Unrelated coding-style changes (other methods, blocks of code, comments, etc.) within a real issue are only accepted for master and in a separate commit.
 1. Coding-style only issues are only accepted for master along the first 2 months of every cycle.
 
 ## Git commits
@@ -1325,6 +1842,8 @@ Git commits should:
 - Include CODE AREA when appropriate. (Code area, is just a short name for the area of Moodle that this change affects. It can be a component name if that makes sense, but does not have to be. Remember that your audience here is humans not computers, so if a shortened version of a component name is more readable and distinctive, use that instead.)
 - Be formatted as:
 
+<ValidExample>
+
 ```
 MDL-xxxx CODE AREA: short summary (72 chars soft limit)
 
@@ -1333,7 +1852,10 @@ following if necessary. This section might include the motivation for the change
 and contrast it with the previous behaviour.
 ```
 
+</ValidExample>
+
 Git commits should not:
+
 - Include changes from bugs found and fixed before integration
 - Include many separate revisions to the same lines of code for a single issue
 - Arbitrarily split when part of a atomic set of logical changes

--- a/src/components.js
+++ b/src/components.js
@@ -1,5 +1,7 @@
 import Since from './components/Since';
 import DeprecatedSince from './components/DeprecatedSince';
+import ValidExample from './components/ValidExample';
+import InvalidExample from './components/InvalidExample';
 
 import CodeBlock from '@theme/CodeBlock';
 import TabItem from '@theme/TabItem';
@@ -8,6 +10,9 @@ import Tabs from '@theme/Tabs';
 export {
     Since,
     DeprecatedSince,
+
+    ValidExample,
+    InvalidExample,
 
     CodeBlock,
     TabItem,

--- a/src/components/InvalidExample/index.js
+++ b/src/components/InvalidExample/index.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import clsx from 'clsx';
+
+export default function ValidExample(props) {
+    return (
+        <div
+            className={clsx(' alert alert--danger margin-bottom--lg ')}
+        >
+            <span class="badge badge--danger">An example of incorrect behaviour</span>
+            {props.children}
+        </div>
+    );
+}

--- a/src/components/ValidExample/index.js
+++ b/src/components/ValidExample/index.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import clsx from 'clsx';
+
+export default function ValidExample(props) {
+    return (
+        <div
+            className={clsx(' alert alert--success margin-bottom--lg ')}
+        >
+            <span class="badge badge--success">An example of correct behaviour</span>
+            {props.children}
+        </div>
+    );
+}


### PR DESCRIPTION
This commit adds the <ValidExample> and <InvalidExample> mdx tags which
allow us to make it clearer the good and bad examples.