### PR TITLE
Link to courses on the Moodle Academy

### DIFF
--- a/academyCourses.js
+++ b/academyCourses.js
@@ -1,0 +1,95 @@
+const courseList = {
+  siteHome: "https://moodle.academy/",
+  courses: {
+    // Each course has a local name to make it easier to map within the documentation.
+    // Please do not remove a name from the list, but instead mark it as archived.
+    setup: {
+      // Valid values are:
+      // - id (int)
+      // - name (string)
+      // - summary (string)
+      // - tags (string[])
+      // - archived (bool)
+      id: 29,
+      name: "Set up your Moodle Development Environment",
+      summary: "Learn about the Moodle developer community and setting up a development environment",
+      description: "This course is designed for PHP developers who want to start developing Moodle plugins. You will learn about the Moodle developer community and set up a Moodle development environment. This is the first course in the Developer Pathway. Subsequent courses in the the Developer Pathway will build on the knowledge gained in this course.",
+      tags: [
+        "development",
+        "basics",
+        "setup",
+      ],
+      archived: false,
+      series: [],
+    },
+    securityEssentials: {
+      id: 53,
+      name: "Moodle Access and Security Essentials",
+      summary: "A short course looking at access control and security aspects of plugins.",
+      description: "In this course we look at access control and security aspects of a plugin. Through a set of tutorials, you will learn how to control access to your plugin using Moodle’s Access API. You will learn how to define capabilities in your plugin and how to determine if the user has the permission to access a page. This course also covers common security threats that developers need to be aware of.\n\nThis is the fourth course in the Moodle Developer Basics program.",
+      tags: [
+          "development",
+          "basic",
+          "essentials",
+          "security",
+          "api",
+      ],
+      archived: false,
+      series: [
+        "basics",
+      ],
+    },
+    outputEssentials: {
+      id: 49,
+      name: "Web Output Essentials",
+      summary: "Learn how to use Moodle's Page and Output APIs to display content in a local plugin.",
+      description: "This course builds on the knowledge gained in the Moodle development environment course. In this course, we learn how to use Moodle's Page and Output APIs to display content in a local plugin. An introduction to localisation using language strings is also covered in this course. This is the second course in the Moodle developer pathway.",
+      tags: [
+        "development",
+        "basics",
+        "essentials",
+        "output",
+        "api",
+      ],
+      archived: false,
+      series: [
+        "basics",
+      ],
+    },
+    architecture: {
+      id: 51,
+      name: "Moodle's Modular Architecture and APIs",
+      summary: "Take a deeper look at Moodle's architecture, exploring common APIs including Navigations, Forms, Database, Upgrade, Strings, and Output.",
+      description: "In this course we take a deeper look at Moodle's modular architecture and explore the use of common Moodle APIs. Some of the APIs covered in this course include: Navigation, Forms, Database access, Upgrade, Strings and Output APIs. Learners get hands-on practise on using these APIs in the form of developing a local plugin.\n\nThis is the third course in the Moodle Developer Basics program.",
+      tags: [
+        "development",
+        "api",
+        "architecture",
+      ],
+      archived: false,
+      series: [
+        "basics",
+      ],
+    },
+    pluginBasics: {
+      id: 10,
+      name: "Moodle Plugin Development Basics",
+      summary: "Learn about the essential concepts in Moodle's moduel architecture.",
+      description: "This course teaches you essential concepts related to Moodle's modular architecture, enabling you to develop a simple demo plugin.\n\nPlease note, this course is being migrated to form a new program of short courses on Moodle Academy (called 'Moodle Developer Basics'), which will all be available at the end of April 2022. For now you may still complete the course on Learn Moodle, or you might like to start the Moodle Academy developer short courses that are being released over the coming weeks and will form this new beginner level program.",
+      tags: [
+        "development",
+        "basics",
+        "essentials",
+        "api",
+        "plugins",
+        "architecture",
+      ],
+      archived: false,
+      series: [
+        "basics",
+      ],
+    }
+  }
+};
+
+module.exports = courseList;

--- a/docs/apis/access.md
+++ b/docs/apis/access.md
@@ -4,6 +4,8 @@ tags:
   - Access
 ---
 
+import AcademyLink from '@site/src/components/AcademyLink';
+
 The Access API gives you functions so you can determine what the current user is allowed to do. It also allows plugins to extend Moodle with new capabilities.
 
 ## Overview
@@ -29,6 +31,12 @@ Roles can be overridden by contexts further down the tree.
 User access is calculated from the combination of roles which are assigned to each user.
 
 All users that did not log-in yet automatically get the default role defined in `$CFG->notloggedinroleid`, it is not possible to assign any other role to this non-existent user id. There is one special guest user account that is used when user logs in using the guest login button or when guest autologin is enabled. Again you can not assign any roles to the guest account directly, this account gets the `$CFG->guestroleid` automatically. All other authenticated users get the default user role specified in `$CFG->defaultuserroleid` and in the frontpage context the role specified in `$CFG->defaultfrontpageroleid`.
+
+
+<AcademyLink
+  subject="Contexts and the Roles API"
+  courseName="securityEssentials"
+/>
 
 ## How to define new capabilities in plugins
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@emotion/react": "^11.8.2",
     "@emotion/styled": "^11.8.1",
     "@mdx-js/react": "^1.6.22",
+    "@mui/icons-material": "^5.6.0",
     "@mui/material": "^5.5.3",
     "clsx": "^1.1.1",
     "dotenv": "^16.0.0",

--- a/src/components.js
+++ b/src/components.js
@@ -1,3 +1,5 @@
+import AcademyLink from './components/AcademyLink';
+
 import Since from './components/Since';
 import DeprecatedSince from './components/DeprecatedSince';
 import ValidExample from './components/ValidExample';
@@ -8,6 +10,8 @@ import TabItem from '@theme/TabItem';
 import Tabs from '@theme/Tabs';
 
 export {
+    AcademyLink,
+
     Since,
     DeprecatedSince,
 

--- a/src/components/AcademyLink.js
+++ b/src/components/AcademyLink.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import Admonition from "@theme/Admonition";
+import Link from '@docusaurus/Link';
+import SchoolIcon from '@mui/icons-material/School';
+import courseList from '@site/academyCourses';
+import { Tooltip } from "@mui/material";
+
+export default function AcademyLink(props) {
+  const courseName = props.courseName;
+  if (!courseList.courses[courseName]) {
+    throw Error(`Unknown course ${courseName}`);
+  }
+
+  const Course = courseList.courses[courseName];
+
+
+  return (
+    <Admonition
+      type="info"
+      icon={
+        <SchoolIcon fontSize="inherit" />
+      }
+      title="Learn more on Moodle Academy"
+    >
+      You can learn more about <strong>{ props.subject }</strong> from the <Tooltip
+        title={ Course.summary }
+      ><Link
+        to={ courseList.siteHome + 'course/view.php?id=' + Course.id }
+      >{ Course.name }</Link></Tooltip> on Moodle Academy.
+    </Admonition>
+  );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2026,6 +2026,13 @@
     prop-types "^15.7.2"
     react-is "^17.0.2"
 
+"@mui/icons-material@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@mui/icons-material/-/icons-material-5.6.0.tgz#bce757f7c7a8eb31b238311a15fa0a0bcdf9ec39"
+  integrity sha512-2GDGt+/BbwM3oVkF84b9FFKQdQ9TxBJIRnTwT99vO2mimdfJaojxMRB2lkysm9tUY4HOf0yoU6O//X6GTC0Zhw==
+  dependencies:
+    "@babel/runtime" "^7.17.2"
+
 "@mui/material@^5.5.3":
   version "5.5.3"
   resolved "https://registry.yarnpkg.com/@mui/material/-/material-5.5.3.tgz#411e53a69da3f9d6664e99f1bdcdaf2760540fdc"


### PR DESCRIPTION
This is part of a change to introduce standard links to courses on
Moodle Academy.

We create a single canonical list of courses in `/academyCourses.js`,
a custom Admonition via a JSX component, and a custom page listing all
academy courses relevant to Development.

That component can take properties to describe:

- the topic being taught
- a short name for the course
- possibly further information to include

The list of courses in academyCourses.js has a list of the courses, with
their shortname as an object key, and then relevant metadata, including:

- The course full name
- The course link or id
- A summary to be used in a tooltip
- A full description to be used in the course list page
- information as to whether the course has been archived
- tags
- icon

The academyCourses page also uses this course information to list all
courses available, with further information and tags.

Fixes #12