### PR TITLE
[repo] Add gitpod configuration for in-browser demo

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,15 @@
+tasks:
+  - init: yarn install
+    command: yarn start
+ports:
+  - port: 3000
+    onOpen: open-preview
+
+github:
+  prebuilds:
+    # add a "Review in Gitpod" button to pull requests (defaults to false)
+    addBadge: true
+    # add a label once the prebuild is ready to pull requests (defaults to false)
+    addLabel: prebuild-in-gitpod
+    # enable for pull requests coming from forks (defaults to false)
+    pullRequestsFromForks: true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Moodle Developer Resoruces
 
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/andrewlyons/dinodevdocs/)
 [![Lint](https://github.com/andrewnicols/dinodevdocs/actions/workflows/markdown-lint.yml/badge.svg)](https://github.com/andrewnicols/dinodevdocs/actions/workflows/markdown-lint.yml)
 [![Build](https://github.com/andrewnicols/dinodevdocs/actions/workflows/pages/pages-build-deployment/badge.svg)](https://github.com/andrewnicols/dinodevdocs/actions/workflows/pages/pages-build-deployment)
 [![Deployment](https://github.com/andrewnicols/dinodevdocs/actions/workflows/deploy.yml/badge.svg)](https://github.com/andrewnicols/dinodevdocs/actions/workflows/deploy.yml)


### PR DESCRIPTION
Add a `.gitpod.yml` configuration to allow for really quick in-browser changes and checking of PRs.

<a href="https://gitpod.io/#https://github.com/andrewnicols/dinodevdocs/pull/42"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

